### PR TITLE
Fix Open Notificaties environment variables

### DIFF
--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -21,3 +21,4 @@ data:
   EMAIL_USE_TLS: "True"
   {{- end }}
   IS_HTTPS: {{ if .Values.settings.isHttps }}"True"{{ else }}"False"{{ end }}
+  RABBITMQ_HOST: {{ include "open-notificaties.fullname" . }}-rabbitmq

--- a/charts/open-notificaties/templates/secret.yaml
+++ b/charts/open-notificaties/templates/secret.yaml
@@ -12,7 +12,7 @@ data:
   {{- if .Values.settings.email.password }}
   EMAIL_PASSWORD: {{ .Values.settings.email.password | toString | b64enc | quote }}
   {{- end }}
-  PUBLISHER_BROKER_URL: {{ .Values.settings.publisherBrokerUrl | toString | b64enc | quote }}
+  PUBLISH_BROKER_URL: {{ .Values.settings.publisherBrokerUrl | toString | b64enc | quote }}
   SECRET_KEY: {{ .Values.settings.secretKey | toString | b64enc | quote }}
   {{- if .Values.settings.sentry.dsn }}
   SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}


### PR DESCRIPTION
* `PUBLISH_BROKER_URL` is the environment variable used in Open Notificaties
* `RABBITMQ_HOST` is missing for the worker (which is missing alltogether, but that's another issue)