### PR TITLE
Updates for latest releases

### DIFF
--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -4,7 +4,7 @@ description: API voor het routeren van notificaties
 
 type: application
 version: 0.5.0
-appVersion: "1.2.1"
+appVersion: "1.2.3"
 
 dependencies:
   - name: postgresql

--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -3,7 +3,7 @@ name: open-notificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 0.4.1
+version: 0.5.0
 appVersion: "1.2.1"
 
 dependencies:

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -44,7 +44,7 @@ table below describes the supported versions
 | `tags.redis` | Install Redis subchart | `true` |
 | `tags.rabbitmq` | Install RabbitMQ subchart | `true` |
 | `image.repository` | The repository of the Docker image | `openzaak/open-notificaties` |
-| `image.tag` | The tag of the Docker image | `1.2.1` |
+| `image.tag` | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
 | `replicaCount` | The number of replicas | `1` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -34,7 +34,7 @@ helm install open-notificaties open-zaak/open-notificaties \
 | `tags.redis` | Install Redis subchart | `true` |
 | `tags.rabbitmq` | Install RabbitMQ subchart | `true` |
 | `image.repository` | The repository of the Docker image | `openzaak/open-notificaties` |
-| `image.tag` | The tag of the Docker image | `latest` |
+| `image.tag` | The tag of the Docker image | `1.2.1` |
 | `replicaCount` | The number of replicas | `1` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
@@ -54,11 +54,9 @@ helm install open-notificaties open-zaak/open-notificaties \
 | `settings.email.username` | The username of the SMTP server | `""` |
 | `settings.email.password` | The password of the SMTP server | `""` |
 | `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
-| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
 | `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
-| `settings.publisherBrokerUrl` | The URL to the publisher broker | `"amqp://guest:guest@open-notificaties-rabbitmq:5672/%2F"` |
-| `settings.celeryBrokerUrl` | The URL to the Celery broker | `"amqp://guest:guest@open-notificaties-rabbitmq:5672//"` |
-| `settings.celeryResultBackend` | The URL to the Celery result backend | `"amqp://guest:guest@open-notificaties-rabbitmq:5672//"` |
+| `settings.messageBroker.host` | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
+| `settings.celery.resultBackend` | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -26,6 +26,16 @@ helm install open-notificaties open-zaak/open-notificaties \
 
 :warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
 
+## Chart and Open Notificaties versions alignment
+
+Not every version of the chart is compatible with every version of Open Notificaties. The
+table below describes the supported versions
+
+| Chart version | Open Notificaties version |
+| ------------- | ------------------------- |
+| < 0.5.0       | < 1.2.0 |
+| 0.5.0         | 1.2.0 + |
+
 ## Configuration
 
 | Parameter | Description | Default |

--- a/charts/open-notificaties/templates/secret.yaml
+++ b/charts/open-notificaties/templates/secret.yaml
@@ -8,7 +8,7 @@ type: Opaque
 data:
   {{ $rabbitmq_url := printf "amqp://%s:%s@%s:5672" .Values.rabbitmq.auth.username .Values.rabbitmq.auth.password .Values.settings.messageBroker.host -}}
   CELERY_BROKER_URL: {{ print $rabbitmq_url "//"  | b64enc | quote }}
-  CELERY_RESULT_BACKEND: {{ print "redis://redis:6379/1" | b64enc | quote }}
+  CELERY_RESULT_BACKEND: {{ .Values.settings.celery.resultBackend | b64enc | quote }}
   DB_PASSWORD: {{ .Values.settings.database.password | toString | b64enc | quote }}
   {{- if .Values.settings.email.password }}
   EMAIL_PASSWORD: {{ .Values.settings.email.password | toString | b64enc | quote }}

--- a/charts/open-notificaties/templates/service.yaml
+++ b/charts/open-notificaties/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 8000
       protocol: TCP
       name: http
   selector:

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -126,6 +126,10 @@ settings:
   messageBroker:
     host: open-notificaties-rabbitmq
 
+  celery:
+    resultBackend: redis://open-notificaties-redis-master:6379/1
+    # TODO: move message broker to this sub-section
+
   isHttps: true
 
   debug: false

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: openzaak/open-notificaties
   pullPolicy: IfNotPresent
-  tag: 1.2.1
+  tag: ""  # uses .Chart.AppVersion by default
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -21,16 +21,16 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsUser: 1000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
 
 livenessProbe:
   initialDelaySeconds: 60

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -4,7 +4,7 @@ description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
 version: 0.5.0
-appVersion: "1.4.0"
+appVersion: "1.5.0"
 
 dependencies:
   - name: postgresql

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -3,7 +3,7 @@ name: open-zaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "1.4.0"
 
 dependencies:

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -42,7 +42,7 @@ table below describes the supported versions
 | `tags.postgresql` | Install PostgreSQL subchart | `true` |
 | `tags.redis` | Install Redis subchart | `true` |
 | `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
-| `image.tag` | The tag of the Docker image | `1.5.0` |
+| `image.tag` | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
 | `replicaCount` | The number of replicas | `1` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -25,6 +25,16 @@ helm install open-zaak open-zaak/open-zaak \
 
 :warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
 
+## Chart and Open Zaak versions alignment
+
+Not every version of the chart is compatible with every version of Open Zaak. The
+table below describes the supported versions
+
+| Chart version | Open Zaak version |
+| ------------- | ----------------- |
+| < 0.5.0       | < 1.5.0 |
+| 0.5.0         | 1.5.0 + |
+
 ## Configuration
 
 | Parameter | Description | Default |

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -42,7 +42,7 @@ table below describes the supported versions
 | `tags.postgresql` | Install PostgreSQL subchart | `true` |
 | `tags.redis` | Install Redis subchart | `true` |
 | `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
-| `image.tag` | The tag of the Docker image | `1.5.0-beta.2` |
+| `image.tag` | The tag of the Docker image | `1.5.0` |
 | `replicaCount` | The number of replicas | `1` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -32,16 +32,19 @@ helm install open-zaak open-zaak/open-zaak \
 | `tags.postgresql` | Install PostgreSQL subchart | `true` |
 | `tags.redis` | Install Redis subchart | `true` |
 | `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
-| `image.tag` | The tag of the Docker image | `latest` |
+| `image.tag` | The tag of the Docker image | `1.5.0-beta.2` |
 | `replicaCount` | The number of replicas | `1` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
 | `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"` |
 | `ingress.tls` | Ingress TLS settings | `"[]"` |
 | `persistence.enabled` | Enable persistency for application media | `false` |
+| `persistence.storageClassName` | Storage class name for the PVC creation, must support RWX | `""` |
 | `persistence.size` | The size of the application media persistent volume | `"1Gi"` |
 | `persistence.existingClaim` | Use an existing claim for application media | `null` |
+| `initContainers.volumePerms` | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true` |
 | `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"` |
+| `settings.useXForwardedHost` | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false` |
 | `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
 | `settings.database.host` | The hostname of PostgreSQL | `"open-zaak-postgresql"` |
 | `settings.database.port` | The port of PostgreSQL | `5432` |

--- a/charts/open-zaak/templates/configmap-nginx.yaml
+++ b/charts/open-zaak/templates/configmap-nginx.yaml
@@ -14,6 +14,9 @@ data:
     proxy_set_header X-Scheme $scheme;
     proxy_connect_timeout 300s;
     proxy_read_timeout 300s;
+    {{- if .Values.useXForwardedHost }}
+    proxy_set_header Host $http_host;
+    {{- end }}
 
     proxy_redirect off;
     proxy_pass_request_headers on;
@@ -22,7 +25,7 @@ data:
 
   default.conf: |
     server {
-      listen       80 default_server;
+      listen       8080 default_server;
       server_name  {{ .Values.settings.allowedHosts  | replace "," " "}} localhost};
       server_tokens off;
 

--- a/charts/open-zaak/templates/configmap.yaml
+++ b/charts/open-zaak/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
     {{- include "open-zaak.labels" . | nindent 4 }}
 data:
   ALLOWED_HOSTS: "{{ include "open-zaak.fullname" . }},{{ .Values.settings.allowedHosts | toString }}"
+  {{- if .Values.useXForwardedHost }}
+  USE_X_FORWARDED_HOST: "True"
+  {{- end }}
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   {{- if .Values.settings.cmis.enabled }}

--- a/charts/open-zaak/templates/deployment.yaml
+++ b/charts/open-zaak/templates/deployment.yaml
@@ -29,6 +29,21 @@ spec:
       serviceAccountName: {{ include "open-zaak.serviceAccountName" . }}
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      {{- if and .Values.persistence.enabled .Values.initContainers.volumePerms }}
+      # fix the file system permissions for the 1.5 upgrade
+      initContainers:
+        - name: volume-perms
+          image: busybox:latest
+          command: ['chown', '-R', '1000:1000', '/app/private-media']
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+            - name: media
+              mountPath: /app/private-media
+      {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -121,21 +136,21 @@ spec:
       containers:
         - name: nginx
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.nginx.securityContext | nindent 12 }}
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
           livenessProbe:
             httpGet:
               path: /_health/
-              port: http
+              port: 8080
             {{- toYaml .Values.nginx.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /
-              port: http
+              port: 8080
             {{- toYaml .Values.nginx.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.nginx.resources | nindent 12 }}

--- a/charts/open-zaak/templates/pvc.yaml
+++ b/charts/open-zaak/templates/pvc.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
+  storageClassName: {{ .Values.persistence.storageClassName }}
   resources:
     requests:
       storage: {{ .Values.persistence.size }}

--- a/charts/open-zaak/templates/service.yaml
+++ b/charts/open-zaak/templates/service.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 8000
       protocol: TCP
       name: http
   selector:
@@ -25,7 +25,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: 8080
       name: http
   selector:
     {{- include "open-zaak.nginxSelectorLabels" . | nindent 4 }}

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -7,11 +7,14 @@ replicaCount: 1
 image:
   repository: openzaak/open-zaak
   pullPolicy: IfNotPresent
-  tag: 1.4.0
+  tag: 1.5.0-beta.2
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+initContainers:
+  volumePerms: true
 
 serviceAccount:
   create: true
@@ -20,16 +23,16 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 1000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
 
 livenessProbe:
   initialDelaySeconds: 60
@@ -89,10 +92,12 @@ affinity: {}
 persistence:
   enabled: false
   size: 1Gi
+  storageClassName: ''
   existingClaim: null
 
 settings:
   allowedHosts: open-zaak.gemeente.nl
+  useXForwardedHost: false
 
   secretKey: SOME-RANDOM-SECRET
 
@@ -129,10 +134,18 @@ settings:
 
 nginx:
   image:
-    repository: nginx
+    repository: nginxinc/nginx-unprivileged
     pullPolicy: IfNotPresent
-    tag: 1.21.1
+    tag: stable
   replicaCount: 1
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 101
+    fsGroup: 1000
   autoscaling:
     enabled: false
   livenessProbe:

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: openzaak/open-zaak
   pullPolicy: IfNotPresent
-  tag: 1.5.0
+  tag: ""  # uses .Chart.AppVersion by default
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: openzaak/open-zaak
   pullPolicy: IfNotPresent
-  tag: 1.5.0-beta.2
+  tag: 1.5.0
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This prepares the charts for Open Zaak 1.5.0

The biggest changes are:

* `securityContext` specified to not run as root - both containers run as UID 1000
* Added init container to fix file system permissions _for existing installations_. You can opt-out of this once the upgrade is done to keep pod/app startup fast.

More details in the release notes of Open Zaak: https://github.com/open-zaak/open-zaak/blob/release/1.5.0/docs/installation/reference/1-5_upgrade.rst (currently in release branch, will be on RTD of course once merged)

**Testing**

Tested this on an older GKE cluster and it deployed fine + file system permissions were indeed corrected. Not guaranteed to work on all storage provisioners, but that's why we have a documentation section.

Pending documentation: https://open-zaak.readthedocs.io/en/release-1.5.0/installation/reference/1-5_upgrade.html