### PR TITLE
Multiple fixes

### DIFF
--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -3,7 +3,7 @@ name: open-zaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.5.0"
 
 dependencies:

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -145,7 +145,6 @@ nginx:
     readOnlyRootFilesystem: false
     runAsNonRoot: true
     runAsUser: 101
-    fsGroup: 1000
   autoscaling:
     enabled: false
   livenessProbe:


### PR DESCRIPTION
When setting `persistence.enabled` to `true` for the Open-Zaak chart, the following error is thrown for the nginx-deployment:

`Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext`

`fsGroup` isn't part of a (container) securityContext object, only of a podSecurityContext object, therefore removed it. 

Fixes #19 