### PR TITLE
Enhancements for Open-Zaak chart

### DIFF
--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -3,7 +3,7 @@ name: open-zaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.5.0"
 
 dependencies:

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -44,6 +44,7 @@ table below describes the supported versions
 | `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
 | `image.tag` | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
 | `replicaCount` | The number of replicas | `1` |
+| `extraPodLabels` | Additional labels to be set on the open-zaak pods | `{}` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
 | `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"` |
@@ -75,6 +76,7 @@ table below describes the supported versions
 | `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `nginx.extraPodLabels` | Additional labels to be set on the nginx pods | `{}` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
 | `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -52,6 +52,7 @@ table below describes the supported versions
 | `persistence.storageClassName` | Storage class name for the PVC creation, must support RWX | `""` |
 | `persistence.size` | The size of the application media persistent volume | `"1Gi"` |
 | `persistence.existingClaim` | Use an existing claim for application media | `null` |
+| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
 | `initContainers.volumePerms` | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true` |
 | `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"` |
 | `settings.useXForwardedHost` | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false` |

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -44,7 +44,7 @@ table below describes the supported versions
 | `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
 | `image.tag` | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
 | `replicaCount` | The number of replicas | `1` |
-| `extraPodLabels` | Additional labels to be set on the open-zaak pods | `{}` |
+| `podLabels` | Additional labels to be set on the open-zaak pods | `{}` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
 | `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"` |
@@ -76,7 +76,7 @@ table below describes the supported versions
 | `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
-| `nginx.extraPodLabels` | Additional labels to be set on the nginx pods | `{}` |
+| `nginx.podLabels` | Additional labels to be set on the nginx pods | `{}` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
 | `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |

--- a/charts/open-zaak/templates/deployment.yaml
+++ b/charts/open-zaak/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "open-zaak.fullname" . }}
+                name: {{ .Values.existingSecret | default (include "open-zaak.fullname" .) }}
             - configMapRef:
                 name: {{ include "open-zaak.fullname" . }}
           ports:

--- a/charts/open-zaak/templates/deployment.yaml
+++ b/charts/open-zaak/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
     {{- include "open-zaak.selectorLabels" . | nindent 8 }}
+    {{- with .Values.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -125,6 +128,9 @@ spec:
         {{- end }}
       labels:
         {{- include "open-zaak.nginxSelectorLabels" . | nindent 8 }}
+        {{- with .Values.nginx.extraPodLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/open-zaak/templates/deployment.yaml
+++ b/charts/open-zaak/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       labels:
     {{- include "open-zaak.selectorLabels" . | nindent 8 }}
-    {{- with .Values.extraPodLabels }}
+    {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
@@ -128,7 +128,7 @@ spec:
         {{- end }}
       labels:
         {{- include "open-zaak.nginxSelectorLabels" . | nindent 8 }}
-        {{- with .Values.nginx.extraPodLabels }}
+        {{- with .Values.nginx.podLabels }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/charts/open-zaak/templates/secret.yaml
+++ b/charts/open-zaak/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   {{- if .Values.settings.sentry.dsn }}
   SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -23,7 +23,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-extraPodLabels: {}
+podLabels: {}
 
 podSecurityContext:
   fsGroup: 1000
@@ -142,7 +142,7 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   replicaCount: 1
-  extraPodLabels: {}
+  podLabels: {}
   securityContext:
     capabilities:
       drop:

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -23,6 +23,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+extraPodLabels: {}
+
 podSecurityContext:
   fsGroup: 1000
 
@@ -140,6 +142,7 @@ nginx:
     pullPolicy: IfNotPresent
     tag: stable
   replicaCount: 1
+  extraPodLabels: {}
   securityContext:
     capabilities:
       drop:

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -95,6 +95,8 @@ persistence:
   storageClassName: ''
   existingClaim: null
 
+existingSecret: null
+
 settings:
   allowedHosts: open-zaak.gemeente.nl
   useXForwardedHost: false


### PR DESCRIPTION
Added the following enhancements:

- added the possibility to bring your own secret (by referring to an already existing secret), in order to avoid secrets management through Helm. 
- added the possibility to set additional labels on pods. 