### PR TITLE
Open-Notificaties Enhancements

### DIFF
--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -3,7 +3,7 @@ name: open-notificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.2.3"
 
 dependencies:

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -73,6 +73,7 @@ table below describes the supported versions
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
 | `settings.flower.urlPrefix` | If enabled, deploy Flower on a non-root URL | `""` |
+| `settings.flower.basicAuth` | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
 | `worker.podLabels` | Additional labels to be set on the open-notification worker pods | `{}` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -46,6 +46,7 @@ table below describes the supported versions
 | `image.repository` | The repository of the Docker image | `openzaak/open-notificaties` |
 | `image.tag` | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
 | `replicaCount` | The number of replicas | `1` |
+| `podLabels` | Additional labels to be set on the open-notification API pods | `{}` |
 | `ingress.enabled` | Expose the application through an ingress | `false` |
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
 | `ingress.hosts` | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
@@ -71,6 +72,7 @@ table below describes the supported versions
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
 | `worker.existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
+| `worker.podLabels` | Additional labels to be set on the open-notification worker pods | `{}` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
 | `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -72,6 +72,7 @@ table below describes the supported versions
 | `settings.celery.resultBackend` | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `settings.flower.urlPrefix` | If enabled, deploy Flower on a non-root URL | `""` |
 | `worker.podLabels` | Additional labels to be set on the open-notification worker pods | `{}` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -81,8 +81,8 @@ table below describes the supported versions
 | `flower.enabled` | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
 | `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
 | `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
-| `flower.envVars.FLOWER_URL_PREFIX` | Deploy Flower on a non-root URL. You can configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `"flower"` | 
-| `flower.secretVars` | Configure Flower through arbitrary environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
+| `flower.extraEnvVars` | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `"flower"` | 
+| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
 | `redis.usePassword` | Use a Redis password | `false` |
 | `redis.cluster.enabled` | Enable Redis cluster | `false` |
 | `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -59,6 +59,7 @@ table below describes the supported versions
 | `settings.database.username` | The username of PostgreSQL | `"postgres"` |
 | `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
 | `settings.database.name` | The database name of PostgreSQL | `"open-notificaties"` |
+| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
 | `settings.cache.default` | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
 | `settings.cache.axes` | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
 | `settings.email.host` | The hostname of the SMTP server | `"localhost"` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -83,7 +83,11 @@ table below describes the supported versions
 | `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
 | `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
 | `flower.extraEnvVars` | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `"flower"` | 
-| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
+| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, 
+| `flower.ingress.enabled` | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
+| `flower.ingress.annotations` | Additional annotations on the Flower Ingress | `{}` |
+| `flower.ingress.hosts` | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
+| `flower.ingress.tls` | Flower Ingress TLS settings | `"[]"` |
 | `redis.usePassword` | Use a Redis password | `false` |
 | `redis.cluster.enabled` | Enable Redis cluster | `false` |
 | `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -50,6 +50,7 @@ table below describes the supported versions
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
 | `ingress.hosts` | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
 | `ingress.tls` | Ingress TLS settings | `"[]"` |
+| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
 | `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
 | `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
 | `settings.database.host` | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
@@ -69,6 +70,7 @@ table below describes the supported versions
 | `settings.celery.resultBackend` | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `worker.existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
 | `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -78,6 +78,12 @@ table below describes the supported versions
 | `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
 | `postgresql.postgresqlDatabase` | The PostgreSQL database name | `"open-notificaties"` |
 | `postgresql.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
+| `flower.enabled` | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
+| `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
+| `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
+| `flower.existingSecret` | Refer to an existing secret, containing Flower specific secrets, to avoid managing secrets through Helm.  | `{}` | 
+| `flower.envVars.FLOWER_URL_PREFIX` | Deploy Flower on a non-root URL. You can configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `"flower"` | 
+| `flower.secretVars` | Configure Flower through arbitrary environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
 | `redis.usePassword` | Use a Redis password | `false` |
 | `redis.cluster.enabled` | Enable Redis cluster | `false` |
 | `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -82,8 +82,8 @@ table below describes the supported versions
 | `flower.enabled` | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
 | `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
 | `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
-| `flower.extraEnvVars` | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `"flower"` | 
-| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, 
+| `flower.extraEnvVars` | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
+| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
 | `flower.ingress.enabled` | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
 | `flower.ingress.annotations` | Additional annotations on the Flower Ingress | `{}` |
 | `flower.ingress.hosts` | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -51,7 +51,7 @@ table below describes the supported versions
 | `ingress.annotations` | Additional annotations on the API ingress | `{}` |
 | `ingress.hosts` | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
 | `ingress.tls` | Ingress TLS settings | `"[]"` |
-| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
+| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
 | `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
 | `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
 | `settings.database.host` | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
@@ -72,7 +72,6 @@ table below describes the supported versions
 | `settings.celery.resultBackend` | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
 | `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
 | `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
-| `worker.existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
 | `worker.podLabels` | Additional labels to be set on the open-notification worker pods | `{}` |
 | `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
 | `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
@@ -82,7 +81,6 @@ table below describes the supported versions
 | `flower.enabled` | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
 | `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
 | `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
-| `flower.existingSecret` | Refer to an existing secret, containing Flower specific secrets, to avoid managing secrets through Helm.  | `{}` | 
 | `flower.envVars.FLOWER_URL_PREFIX` | Deploy Flower on a non-root URL. You can configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `"flower"` | 
 | `flower.secretVars` | Configure Flower through arbitrary environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
 | `redis.usePassword` | Use a Redis password | `false` |

--- a/charts/open-notificaties/templates/_helpers.tpl
+++ b/charts/open-notificaties/templates/_helpers.tpl
@@ -99,3 +99,35 @@ Worker selector labels
 app.kubernetes.io/name: {{ include "open-notificaties.workerName" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create a name for Flower
+We truncate at 56 chars in order to provide space for the "-flower" suffix
+*/}}
+{{- define "open-notificaties.flowerName" -}}
+{{ include "open-notificaties.name" . | trunc 57 | trimSuffix "-" }}-flower
+{{- end }}
+
+{{/*
+Create a default fully qualified name for Flower.
+We truncate at 56 chars in order to provide space for the "-flower" suffix
+*/}}
+{{- define "open-notificaties.flowerFullname" -}}
+{{ include "open-notificaties.fullname" . | trunc 57 | trimSuffix "-" }}-flower
+{{- end }}
+
+{{/*
+Flower labels
+*/}}
+{{- define "open-notificaties.flowerLabels" -}}
+{{ include "open-notificaties.commonLabels" . }}
+{{ include "open-notificaties.flowerSelectorLabels" . }}
+{{- end }}
+
+{{/*
+Flower selector labels
+*/}}
+{{- define "open-notificaties.flowerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "open-notificaties.flowerName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/open-notificaties/templates/_helpers.tpl
+++ b/charts/open-notificaties/templates/_helpers.tpl
@@ -105,15 +105,15 @@ Create a name for Flower
 We truncate at 56 chars in order to provide space for the "-flower" suffix
 */}}
 {{- define "open-notificaties.flowerName" -}}
-{{ include "open-notificaties.name" . | trunc 57 | trimSuffix "-" }}-flower
+{{ include "open-notificaties.name" . | trunc 56 | trimSuffix "-" }}-flower
 {{- end }}
 
 {{/*
 Create a default fully qualified name for Flower.
-We truncate at 56 chars in order to provide space for the "-flower" suffix
+We truncate at 57 chars in order to provide space for the "-flower" suffix
 */}}
 {{- define "open-notificaties.flowerFullname" -}}
-{{ include "open-notificaties.fullname" . | trunc 57 | trimSuffix "-" }}-flower
+{{ include "open-notificaties.fullname" . | trunc 56 | trimSuffix "-" }}-flower
 {{- end }}
 
 {{/*

--- a/charts/open-notificaties/templates/_helpers.tpl
+++ b/charts/open-notificaties/templates/_helpers.tpl
@@ -110,7 +110,7 @@ We truncate at 56 chars in order to provide space for the "-flower" suffix
 
 {{/*
 Create a default fully qualified name for Flower.
-We truncate at 57 chars in order to provide space for the "-flower" suffix
+We truncate at 56 chars in order to provide space for the "-flower" suffix
 */}}
 {{- define "open-notificaties.flowerFullname" -}}
 {{ include "open-notificaties.fullname" . | trunc 56 | trimSuffix "-" }}-flower

--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -22,3 +22,8 @@ data:
   {{- end }}
   IS_HTTPS: {{ if .Values.settings.isHttps }}"True"{{ else }}"False"{{ end }}
   RABBITMQ_HOST: {{ .Values.settings.messageBroker.host }}
+  {{- if .Values.flower.enabled }}
+  {{- range $index, $index_value := .Values.flower.envVars }}
+  {{ $index }}: {{ $index_value | toString | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -23,6 +23,9 @@ data:
   {{- end }}
   IS_HTTPS: {{ if .Values.settings.isHttps }}"True"{{ else }}"False"{{ end }}
   RABBITMQ_HOST: {{ .Values.settings.messageBroker.host }}
+  {{- if .Values.settings.flower.urlPrefix }}
+  FLOWER_URL_PREFIX: {{ .Values.settings.flower.urlPrefix }}
+  {{- end }}
   {{- if .Values.flower.enabled }}
   {{- range $index, $index_value := .Values.flower.extraEnvVars }}
   {{ $index }}: {{ $index_value | toString | quote }}

--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
   IS_HTTPS: {{ if .Values.settings.isHttps }}"True"{{ else }}"False"{{ end }}
   RABBITMQ_HOST: {{ .Values.settings.messageBroker.host }}
   {{- if .Values.flower.enabled }}
-  {{- range $index, $index_value := .Values.flower.envVars }}
+  {{- range $index, $index_value := .Values.flower.extraEnvVars }}
   {{ $index }}: {{ $index_value | toString | quote }}
   {{- end }}
   {{- end }}

--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   DB_HOST: {{ .Values.settings.database.host | toString | quote }}
   DB_PORT: {{ .Values.settings.database.port | toString | quote }}
   DB_USER: {{ .Values.settings.database.username | toString | quote }}
+  PGSSLMODE: {{ .Values.settings.database.sslmode | toString | quote }}
   DEBUG: {{ if .Values.settings.debug }}"True"{{ else }}"False"{{ end }}
   EMAIL_HOST: {{ .Values.settings.email.host | toString | quote }}
   {{- if .Values.settings.email.username }}

--- a/charts/open-notificaties/templates/deployment.yaml
+++ b/charts/open-notificaties/templates/deployment.yaml
@@ -148,9 +148,7 @@ metadata:
   labels:
   {{- include "open-notificaties.flowerLabels" . | nindent 4 }}
 spec:
-  {{- if not .Values.flower.autoscaling.enabled }}
   replicas: {{ .Values.flower.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "open-notificaties.flowerSelectorLabels" . | nindent 6 }}

--- a/charts/open-notificaties/templates/deployment.yaml
+++ b/charts/open-notificaties/templates/deployment.yaml
@@ -139,5 +139,79 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-
-
+---
+{{- if .Values.flower.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "open-notificaties.flowerFullname" . }}
+  labels:
+  {{- include "open-notificaties.flowerLabels" . | nindent 4 }}
+spec:
+  {{- if not .Values.flower.autoscaling.enabled }}
+  replicas: {{ .Values.flower.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "open-notificaties.flowerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+    {{- include "open-notificaties.flowerSelectorLabels" . | nindent 8 }}
+    {{- with .Values.flower.podLabels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "open-notificaties.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-flower
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.flower.existingSecret | default (include "open-notificaties.fullname" .) }}
+            - configMapRef:
+                name: {{ include "open-notificaties.fullname" . }}
+          ports:
+            - name: http
+              containerPort: 5555
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 5555
+            {{- toYaml .Values.flower.livenessProbe | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: 5555
+            {{- toYaml .Values.flower.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.flower.resources | nindent 12 }}
+          command:
+            - /celery_flower.sh
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/open-notificaties/templates/deployment.yaml
+++ b/charts/open-notificaties/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "open-notificaties.fullname" . }}
+                name: {{ .Values.existingSecret | default (include "open-notificaties.fullname" .) }}
             - configMapRef:
                 name: {{ include "open-notificaties.fullname" . }}
           ports:
@@ -114,7 +114,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "open-notificaties.fullname" . }}
+                name: {{ .Values.worker.existingSecret | default (include "open-notificaties.fullname" .) }}
             - configMapRef:
                 name: {{ include "open-notificaties.fullname" . }}
           resources:

--- a/charts/open-notificaties/templates/deployment.yaml
+++ b/charts/open-notificaties/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         {{- end }}
       labels:
         {{- include "open-notificaties.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -98,6 +101,9 @@ spec:
         {{- end }}
       labels:
     {{- include "open-notificaties.workerSelectorLabels" . | nindent 8 }}
+    {{- with .Values.worker.podLabels }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/open-notificaties/templates/deployment.yaml
+++ b/charts/open-notificaties/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ .Values.worker.existingSecret | default (include "open-notificaties.fullname" .) }}
+                name: {{ .Values.existingSecret | default (include "open-notificaties.fullname" .) }}
             - configMapRef:
                 name: {{ include "open-notificaties.fullname" . }}
           resources:
@@ -183,7 +183,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ .Values.flower.existingSecret | default (include "open-notificaties.fullname" .) }}
+                name: {{ .Values.existingSecret | default (include "open-notificaties.fullname" .) }}
             - configMapRef:
                 name: {{ include "open-notificaties.fullname" . }}
           ports:

--- a/charts/open-notificaties/templates/hpa.yaml
+++ b/charts/open-notificaties/templates/hpa.yaml
@@ -55,3 +55,32 @@ spec:
         targetAverageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}
+---
+{{- if .Values.flower.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "open-notificaties.flowerFullname" . }}
+  labels:
+  {{- include "open-notificaties.flowerLabels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "open-notificaties.flowerFullname" . }}
+  minReplicas: {{ .Values.flower.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.flower.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.flower.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.flower.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.flower.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.flower.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/charts/open-notificaties/templates/hpa.yaml
+++ b/charts/open-notificaties/templates/hpa.yaml
@@ -55,32 +55,3 @@ spec:
         targetAverageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}
----
-{{- if .Values.flower.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: {{ include "open-notificaties.flowerFullname" . }}
-  labels:
-  {{- include "open-notificaties.flowerLabels" . | nindent 4 }}
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: {{ include "open-notificaties.flowerFullname" . }}
-  minReplicas: {{ .Values.flower.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.flower.autoscaling.maxReplicas }}
-  metrics:
-    {{- if .Values.flower.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.flower.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
-    {{- if .Values.flower.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        targetAverageUtilization: {{ .Values.flower.autoscaling.targetMemoryUtilizationPercentage }}
-  {{- end }}
-{{- end }}

--- a/charts/open-notificaties/templates/ingress.yaml
+++ b/charts/open-notificaties/templates/ingress.yaml
@@ -2,9 +2,10 @@
 {{- $fullName := include "open-notificaties.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $flowerEnabled := .Values.flower.enabled }}
+{{- $flowerIngressEnabled := .Values.flower.ingress.enabled }}
 {{- $flowerFullName := include "open-notificaties.flowerFullname" . -}}
 {{- $flowerSvcPort := .Values.flower.service.port -}}
-{{- $flowerUrlPrefix := .Values.flower.envVars.FLOWER_URL_PREFIX -}}
+{{- $flowerUrlPrefix := .Values.settings.flower.urlPrefix -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -39,11 +40,53 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
-          {{- if $flowerEnabled }}
+          {{- if and ($flowerEnabled) (not $flowerIngressEnabled) }}
           - path: /{{ $flowerUrlPrefix }}
             backend:
               serviceName: {{ $flowerFullName }}
               servicePort: {{ $flowerSvcPort }}
           {{- end }}
+    {{- end }}
+  {{- end }}
+
+---
+{{- if .Values.flower.ingress.enabled -}}
+{{- $fullName := include "open-notificaties.flowerFullname" . -}}
+{{- $svcPort := .Values.flower.service.port -}}
+{{- $flowerUrlPrefix := .Values.settings.flower.urlPrefix -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "open-notificaties.labels" . | nindent 4 }}
+  {{- with .Values.flower.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.flower.ingress.tls }}
+  tls:
+    {{- range .Values.flower.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.flower.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /{{ $flowerUrlPrefix }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
     {{- end }}
   {{- end }}

--- a/charts/open-notificaties/templates/ingress.yaml
+++ b/charts/open-notificaties/templates/ingress.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "open-notificaties.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $flowerEnabled := .Values.flower.enabled }}
+{{- $flowerFullName := include "open-notificaties.flowerFullname" . -}}
+{{- $flowerSvcPort := .Values.flower.service.port -}}
+{{- $flowerUrlPrefix := .Values.flower.envVars.FLOWER_URL_PREFIX -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
@@ -35,5 +39,11 @@ spec:
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+          {{- if $flowerEnabled }}
+          - path: /{{ $flowerUrlPrefix }}
+            backend:
+              serviceName: {{ $flowerFullName }}
+              servicePort: {{ $flowerSvcPort }}
+          {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/open-notificaties/templates/secret.yaml
+++ b/charts/open-notificaties/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,3 +19,4 @@ data:
   {{- if .Values.settings.sentry.dsn }}
   SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/open-notificaties/templates/secret.yaml
+++ b/charts/open-notificaties/templates/secret.yaml
@@ -20,7 +20,7 @@ data:
   SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
   {{- end }}
   {{- if .Values.flower.enabled }}
-  {{- range $index, $index_value := .Values.flower.secretVars }}
+  {{- range $index, $index_value := .Values.flower.extraEnvVarsSecret }}
   {{ $index }}: {{ $index_value | toString | b64enc | quote }}
   {{- end }}
   {{- end }}

--- a/charts/open-notificaties/templates/secret.yaml
+++ b/charts/open-notificaties/templates/secret.yaml
@@ -20,6 +20,7 @@ data:
   SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
   {{- end }}
   {{- if .Values.flower.enabled }}
+  FLOWER_BASIC_AUTH: {{ .Values.settings.flower.basicAuth | toString | b64enc | quote }}
   {{- range $index, $index_value := .Values.flower.extraEnvVarsSecret }}
   {{ $index }}: {{ $index_value | toString | b64enc | quote }}
   {{- end }}

--- a/charts/open-notificaties/templates/secret.yaml
+++ b/charts/open-notificaties/templates/secret.yaml
@@ -19,4 +19,9 @@ data:
   {{- if .Values.settings.sentry.dsn }}
   SENTRY_DSN: {{ .Values.settings.sentry.dsn | toString | b64enc | quote }}
   {{- end }}
+  {{- if .Values.flower.enabled }}
+  {{- range $index, $index_value := .Values.flower.secretVars }}
+  {{ $index }}: {{ $index_value | toString | b64enc | quote }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/open-notificaties/templates/service.yaml
+++ b/charts/open-notificaties/templates/service.yaml
@@ -13,3 +13,21 @@ spec:
       name: http
   selector:
     {{- include "open-notificaties.selectorLabels" . | nindent 4 }}
+---
+{{- if .Values.flower.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "open-notificaties.flowerFullname" . }}
+  labels:
+    {{- include "open-notificaties.flowerLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.flower.service.type }}
+  ports:
+    - port: {{ .Values.flower.service.port }}
+      targetPort: 5555
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "open-notificaties.flowerSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -122,9 +122,9 @@ flower:
     failureThreshold: 6
     successThreshold: 1
   resources: {}
-  envVars: 
+  extraEnvVars: 
     FLOWER_URL_PREFIX: flower
-  secretVars: {}
+  extraEnvVarsSecret: {}
 
 settings:
   allowedHosts: open-notificaties.gemeente.nl

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -124,6 +124,17 @@ flower:
   resources: {}
   extraEnvVars: {}
   extraEnvVarsSecret: {}
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - open-notificaties.gemeente.nl
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
 settings:
   allowedHosts: open-notificaties.gemeente.nl

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -32,6 +32,8 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+existingSecret: null
+
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 10
@@ -89,6 +91,7 @@ affinity: {}
 
 worker:
   replicaCount: 1
+  existingSecret: null
   resources: {}
   autoscaling:
     enabled: false

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -103,6 +103,37 @@ worker:
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
+flower:
+  enabled: true
+  replicaCount: 1
+  podLabels: {}
+  existingSecret: null
+  service:
+    type: ClusterIP
+    port: 80
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  resources: {}
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 100
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  envVars: 
+    FLOWER_URL_PREFIX: flower
+  secretVars: {}
+
 settings:
   allowedHosts: open-notificaties.gemeente.nl
 

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -21,6 +21,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext:
   runAsUser: 1000
 
@@ -91,6 +93,7 @@ affinity: {}
 
 worker:
   replicaCount: 1
+  podLabels: {}
   existingSecret: null
   resources: {}
   autoscaling:

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -124,12 +124,6 @@ flower:
     failureThreshold: 6
     successThreshold: 1
   resources: {}
-  autoscaling:
-    enabled: false
-    minReplicas: 1
-    maxReplicas: 100
-    targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
   envVars: 
     FLOWER_URL_PREFIX: flower
   secretVars: {}

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -145,6 +145,7 @@ settings:
     username: postgres
     password: SUPER-SECRET
     name: open-notificaties
+    sslmode: prefer
 
   email:
     host: localhost

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -94,7 +94,6 @@ affinity: {}
 worker:
   replicaCount: 1
   podLabels: {}
-  existingSecret: null
   resources: {}
   autoscaling:
     enabled: false
@@ -107,7 +106,6 @@ flower:
   enabled: true
   replicaCount: 1
   podLabels: {}
-  existingSecret: null
   service:
     type: ClusterIP
     port: 80

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -122,8 +122,7 @@ flower:
     failureThreshold: 6
     successThreshold: 1
   resources: {}
-  extraEnvVars: 
-    FLOWER_URL_PREFIX: flower
+  extraEnvVars: {}
   extraEnvVarsSecret: {}
 
 settings:
@@ -163,6 +162,9 @@ settings:
   isHttps: true
 
   debug: false
+
+  flower:
+    urlPrefix: ""
 
 #######################
 # PostgreSQL subchart #

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -176,6 +176,7 @@ settings:
 
   flower:
     urlPrefix: ""
+    basicAuth: ""
 
 #######################
 # PostgreSQL subchart #

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -3,7 +3,7 @@ name: open-zaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "1.5.0"
 
 dependencies:

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -63,6 +63,7 @@ table below describes the supported versions
 | `settings.database.username` | The username of PostgreSQL | `"postgres"` |
 | `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
 | `settings.database.name` | The database name of PostgreSQL | `"open-zaak"` |
+| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
 | `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"` |
 | `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"` |
 | `settings.email.host` | The hostname of the SMTP server | `"localhost"` |

--- a/charts/open-zaak/templates/configmap.yaml
+++ b/charts/open-zaak/templates/configmap.yaml
@@ -21,6 +21,7 @@ data:
   DB_HOST: {{ .Values.settings.database.host | toString | quote }}
   DB_PORT: {{ .Values.settings.database.port | toString | quote }}
   DB_USER: {{ .Values.settings.database.username | toString | quote }}
+  PGSSLMODE: {{ .Values.settings.database.sslmode | toString | quote }}
   DEBUG: {{ if .Values.settings.debug }}"True"{{ else }}"False"{{ end }}
   EMAIL_HOST: {{ .Values.settings.email.host | toString | quote }}
   {{- if .Values.settings.email.username }}

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -111,6 +111,7 @@ settings:
     username: postgres
     password: SUPER-SECRET
     name: open-zaak
+    sslmode: prefer
 
   email:
     host: localhost


### PR DESCRIPTION
- [1cadaa2f59102d42c23b1a3681dff4a367728a9c] Support for Celery Flower deployment (Fixes #17)
- [a1105c797a67300291e72e7733d25fb497a9f715] Now possible to bring your own secret (by referring to an already existing secret), in order to avoid secrets management through Helm.
- [264f66485d30dc7cbd84680d1318fb8fa0a3b7f6] Set additional labels on pods.
- [c56aefc83ceea0e2b32b1f975fc3882a1bf4955d] Set the PGSSLMODE environment variable, which gives the ability to influence which SSL-mode is used by the postgres client. Also ported this to the `Open-Zaak` chart. 

**Testing**
These changes have been successfully tested on the Gemeente Utrecht environment. 