### PR TITLE
Update to ON 1.3.0 and OZ 1.6.0

### DIFF
--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -3,7 +3,7 @@ name: open-notificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: "1.3.0"
 
 dependencies:

--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -4,7 +4,7 @@ description: API voor het routeren van notificaties
 
 type: application
 version: 0.6.0
-appVersion: "1.2.3"
+appVersion: "1.3.0"
 
 dependencies:
   - name: postgresql

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -34,7 +34,8 @@ table below describes the supported versions
 | Chart version | Open Notificaties version |
 | ------------- | ------------------------- |
 | < 0.5.0       | < 1.2.0 |
-| 0.5.0         | 1.2.0 + |
+| 0.5.0         | 1.2.x   |
+| 0.7.0         | 1.3.0 + |
 
 ## Configuration
 

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -60,6 +60,7 @@ table below describes the supported versions
 | `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
 | `settings.database.name` | The database name of PostgreSQL | `"open-notificaties"` |
 | `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
+| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
 | `settings.cache.default` | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
 | `settings.cache.axes` | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
 | `settings.email.host` | The hostname of the SMTP server | `"localhost"` |

--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -14,6 +14,7 @@ data:
   DB_USER: {{ .Values.settings.database.username | toString | quote }}
   PGSSLMODE: {{ .Values.settings.database.sslmode | toString | quote }}
   DEBUG: {{ if .Values.settings.debug }}"True"{{ else }}"False"{{ end }}
+  NUM_PROXIES: {{ .Values.settings.numProxies | toString | quote }}
   EMAIL_HOST: {{ .Values.settings.email.host | toString | quote }}
   {{- if .Values.settings.email.username }}
   EMAIL_USER: {{ .Values.settings.email.username | toString | quote }}

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -149,6 +149,8 @@ settings:
     name: open-notificaties
     sslmode: prefer
 
+  numProxies: 0  # use 1 if enabling ingress
+
   email:
     host: localhost
     port: 25

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -3,7 +3,7 @@ name: open-zaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "1.6.0"
 
 dependencies:

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -4,7 +4,7 @@ description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
 version: 0.7.0
-appVersion: "1.5.0"
+appVersion: "1.6.0"
 
 dependencies:
   - name: postgresql

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -64,6 +64,7 @@ table below describes the supported versions
 | `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
 | `settings.database.name` | The database name of PostgreSQL | `"open-zaak"` |
 | `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
+| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`  |
 | `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"` |
 | `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"` |
 | `settings.email.host` | The hostname of the SMTP server | `"localhost"` |

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -33,7 +33,8 @@ table below describes the supported versions
 | Chart version | Open Zaak version |
 | ------------- | ----------------- |
 | < 0.5.0       | < 1.5.0 |
-| 0.5.0         | 1.5.0 + |
+| 0.5.0         | 1.5.x   |
+| 0.7.0         | 1.6.0 + |
 
 ## Configuration
 

--- a/charts/open-zaak/templates/configmap.yaml
+++ b/charts/open-zaak/templates/configmap.yaml
@@ -23,6 +23,7 @@ data:
   DB_USER: {{ .Values.settings.database.username | toString | quote }}
   PGSSLMODE: {{ .Values.settings.database.sslmode | toString | quote }}
   DEBUG: {{ if .Values.settings.debug }}"True"{{ else }}"False"{{ end }}
+  NUM_PROXIES: {{ .Values.settings.numProxies | toString | quote }}
   EMAIL_HOST: {{ .Values.settings.email.host | toString | quote }}
   {{- if .Values.settings.email.username }}
   EMAIL_USER: {{ .Values.settings.email.username | toString | quote }}

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -113,6 +113,8 @@ settings:
     name: open-zaak
     sslmode: prefer
 
+  numProxies: 1  # use 2 if enabling ingress
+
   email:
     host: localhost
     port: 25


### PR DESCRIPTION
~~**Both are still unreleased, which is why the PR is a draft PR**~~

---

* Bumped appVersion in chart manifests
* Added the new `NUM_PROXIES` envvars with defaults matching the `ingress.enabled: false` default. See the OZ release notes for the meaning of this config parameter.