### PR TITLE
Bugfix: Ingress port name is a number

### DIFF
--- a/charts/open-zaak/templates/ingress.yaml
+++ b/charts/open-zaak/templates/ingress.yaml
@@ -42,13 +42,13 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: {{ $svcPort }}
+                  name: http
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end}}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: ImplementationSpecific
-            {{- end }} 
+            {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/open-zaak/templates/ingress.yaml
+++ b/charts/open-zaak/templates/ingress.yaml
@@ -49,6 +49,6 @@ spec:
               {{- end}}
             {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
             pathType: ImplementationSpecific
-            {{- end }}
+            {{- end }} 
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Bugfix: Ingress port name must point to a name, not a number.
Fixes #31