### PR TITLE
Fix open-zaak chart dependencies

### DIFF
--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 version: 0.8.1
 appVersion: "1.7.1"
 
-# dependencies:
-#   - name: postgresql
-#     version: ~10.12.0
-#     repository: https://charts.bitnami.com/bitnami
-#     tags:
-#       - postgresql
-#   - name: redis
-#     version: ~13.0.0
-#     repository: https://charts.bitnami.com/bitnami
-#     tags:
-#       - redis
+dependencies:
+  - name: postgresql
+    version: ~15.5.5
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - postgresql
+  - name: redis
+    version: ~19.5.2
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - redis

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -23,6 +23,10 @@ helm install open-zaak open-zaak/open-zaak \
     --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
+:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+
+:warning: When you uninstall the chart, the PVCs will not be deleted. This can cause confusion during testing.
+
 If you want to use your own instance of Redis and Postgres instead, you can disable the subcharts:
 
 ```bash
@@ -38,7 +42,7 @@ helm install open-zaak open-zaak/open-zaak \
 --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
-:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+You will probably need to set more values to configure the connection to your own Redis and Postgres instances.
 
 ## Chart and Open Zaak versions alignment
 

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -23,6 +23,21 @@ helm install open-zaak open-zaak/open-zaak \
     --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
+If you want to use your own instance of Redis and Postgres instead, you can disable the subcharts:
+
+```bash
+
+helm install open-zaak open-zaak/open-zaak \
+--set "tags.redis=false" \
+--set "tags.postgresql=false" \
+--set "settings.database.host=postgres.gemeente.nl" \
+--set "settings.cache.default=redis.gemeente.nl:6379/0" \
+--set "settings.cache.axes=redis.gemeente.nl:6379/0" \
+--set "settings.allowedHosts=open-zaak.gemeente.nl" \
+--set "ingress.enabled=true" \
+--set "ingress.hosts={open-zaak.gemeente.nl}"
+```
+
 :warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
 
 ## Chart and Open Zaak versions alignment

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -186,9 +186,11 @@ postgresql:
     size: 1Gi
     existingClaim: null
 
-  auth:
-    database: open-zaak
-    postgresPassword: SUPER-SECRET
+  global:
+    postgresql:
+      auth:
+        database: open-zaak
+        postgresPassword: SUPER-SECRET
 
 ##################
 # Redis subchart #

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -59,7 +59,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  className: ""    
+  className: ""
   hosts:
     - open-zaak.gemeente.nl
   tls: []
@@ -186,8 +186,9 @@ postgresql:
     size: 1Gi
     existingClaim: null
 
-  postgresqlDatabase: open-zaak
-  postgresqlPassword: SUPER-SECRET
+  auth:
+    database: open-zaak
+    postgresPassword: SUPER-SECRET
 
 ##################
 # Redis subchart #


### PR DESCRIPTION
- Enabled subcharts again
- Updated outdated dependencies in the open-zaak chart.
- Added command to ReadMe how to skip the subcharts.

I have tested this change both with and without subcharts.
Fixes #33
