### PR TITLE
Open-Zaak 1.12.4, Open-Notificaties 1.6.0

### DIFF
--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -3,8 +3,9 @@ name: open-notificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 0.8.1
-appVersion: "1.4.0"
+version: 0.8.2
+# https://github.com/open-zaak/open-notificaties/tags
+appVersion: "1.6.0"
 
 dependencies:
   - name: postgresql

--- a/charts/open-notificaties/Chart.yaml
+++ b/charts/open-notificaties/Chart.yaml
@@ -3,22 +3,22 @@ name: open-notificaties
 description: API voor het routeren van notificaties
 
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "1.4.0"
 
 dependencies:
   - name: postgresql
-    version: ~10.12.0
+    version: ~15.5.5
     repository: https://charts.bitnami.com/bitnami
     tags:
       - postgresql
   - name: redis
-    version: ~13.0.0
+    version: ~19.5.2
     repository: https://charts.bitnami.com/bitnami
     tags:
       - redis
   - name: rabbitmq
-    version: ~8.23.0
+    version: ~14.4.1
     repository: https://charts.bitnami.com/bitnami
     tags:
       - rabbitmq

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -62,71 +62,70 @@ table below describes the supported versions
 
 ## Configuration
 
-| Parameter                                              | Description | Default |
-|--------------------------------------------------------| ----------- | ------- |
-| `tags.postgresql`                                      | Install PostgreSQL subchart | `true` |
-| `tags.redis`                                           | Install Redis subchart | `true` |
-| `tags.rabbitmq`                                        | Install RabbitMQ subchart | `true` |
-| `image.repository`                                     | The repository of the Docker image | `openzaak/open-notificaties` |
-| `image.tag`                                            | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
-| `replicaCount`                                         | The number of replicas | `1` |
-| `podLabels`                                            | Additional labels to be set on the open-notification API pods | `{}` |
-| `ingress.enabled`                                      | Expose the application through an ingress | `false` |
-| `ingress.annotations`                                  | Additional annotations on the API ingress | `{}` |
-| `ingress.hosts`                                        | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
-| `ingress.tls`                                          | Ingress TLS settings | `"[]"` |
-| `existingSecret`                                       | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
-| `settings.allowedHosts`                                | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
-| `settings.secretKey`                                   | The secret key of the application | `"SOME-RANDOM-SECRET"` |
-| `settings.database.host`                               | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
-| `settings.database.port`                               | The port of PostgreSQL | `5432` |
-| `settings.database.username`                           | The username of PostgreSQL | `"postgres"` |
-| `settings.database.password`                           | The password of PostgreSQL | `"SUPER-SECRET"` |
-| `settings.database.name`                               | The database name of PostgreSQL | `"open-notificaties"` |
-| `settings.database.sslmode`                            | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
-| `settings.numProxies`                                  | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
-| `settings.cache.default`                               | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
-| `settings.cache.axes`                                  | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
-| `settings.email.host`                                  | The hostname of the SMTP server | `"localhost"` |
-| `settings.email.port`                                  | The port of the SMTP server | `25` |
-| `settings.email.username`                              | The username of the SMTP server | `""` |
-| `settings.email.password`                              | The password of the SMTP server | `""` |
-| `settings.email.useTLS`                                | Use TLS for connecting to SMTP server | `false` |
-| `settings.sentry.dsn`                                  | The DSN for Sentry Logging | `""` |
-| `settings.messageBroker.host`                          | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
-| `settings.celery.resultBackend`                        | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
-| `settings.isHttps`                                     | Used to construct absolute URLs and controls a variety of security settings | `true` |
-| `settings.debug`                                       | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
-| `settings.autoRetry.maxRetries`                        | Maximum number of notification delivery retries. If `null`, the upstream defaults are used. | `null` |
-| `settings.autoRetry.backoff`                           | Exponential backoff, boolean or number. If a number, applies as a scale factor. If `null`, the upstream defaults are used. | `null` |
-| `settings.autoRetry.backoffMax`                        | Upper limit (in seconds) of the exponential backoff. If `null`, the upstream defaults are used. | `null` |
-| `settings.flower.urlPrefix`                            | If enabled, deploy Flower on a non-root URL | `""` |
-| `settings.flower.basicAuth`                            | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
-| `worker.podLabels`                                     | Additional labels to be set on the open-notification worker pods | `{}` |
-| `postgresql.persistence.enabled`                       | Enable PostgreSQL persistency | `false` |
-| `postgresql.persistence.size`                          | Configure PostgreSQL size | `"1Gi"` |
-| `postgresql.persistence.existingClaim`                 | Use an existing persistent volume claim | `null` |
-| `postgresql.global.postgresql.auth.database`           | The PostgreSQL database name | `"open-notificaties"` |
+| Parameter                                             | Description | Default |
+|-------------------------------------------------------| ----------- | ------- |
+| `tags.postgresql`                                     | Install PostgreSQL subchart | `true` |
+| `tags.redis`                                          | Install Redis subchart | `true` |
+| `tags.rabbitmq`                                       | Install RabbitMQ subchart | `true` |
+| `image.repository`                                    | The repository of the Docker image | `openzaak/open-notificaties` |
+| `image.tag`                                           | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
+| `replicaCount`                                        | The number of replicas | `1` |
+| `podLabels`                                           | Additional labels to be set on the open-notification API pods | `{}` |
+| `ingress.enabled`                                     | Expose the application through an ingress | `false` |
+| `ingress.annotations`                                 | Additional annotations on the API ingress | `{}` |
+| `ingress.hosts`                                       | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
+| `ingress.tls`                                         | Ingress TLS settings | `"[]"` |
+| `existingSecret`                                      | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
+| `settings.allowedHosts`                               | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
+| `settings.secretKey`                                  | The secret key of the application | `"SOME-RANDOM-SECRET"` |
+| `settings.database.host`                              | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
+| `settings.database.port`                              | The port of PostgreSQL | `5432` |
+| `settings.database.username`                          | The username of PostgreSQL | `"postgres"` |
+| `settings.database.password`                          | The password of PostgreSQL | `"SUPER-SECRET"` |
+| `settings.database.name`                              | The database name of PostgreSQL | `"open-notificaties"` |
+| `settings.database.sslmode`                           | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
+| `settings.numProxies`                                 | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
+| `settings.cache.default`                              | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
+| `settings.cache.axes`                                 | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
+| `settings.email.host`                                 | The hostname of the SMTP server | `"localhost"` |
+| `settings.email.port`                                 | The port of the SMTP server | `25` |
+| `settings.email.username`                             | The username of the SMTP server | `""` |
+| `settings.email.password`                             | The password of the SMTP server | `""` |
+| `settings.email.useTLS`                               | Use TLS for connecting to SMTP server | `false` |
+| `settings.sentry.dsn`                                 | The DSN for Sentry Logging | `""` |
+| `settings.messageBroker.host`                         | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
+| `settings.celery.resultBackend`                       | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
+| `settings.isHttps`                                    | Used to construct absolute URLs and controls a variety of security settings | `true` |
+| `settings.debug`                                      | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `settings.autoRetry.maxRetries`                       | Maximum number of notification delivery retries. If `null`, the upstream defaults are used. | `null` |
+| `settings.autoRetry.backoff`                          | Exponential backoff, boolean or number. If a number, applies as a scale factor. If `null`, the upstream defaults are used. | `null` |
+| `settings.autoRetry.backoffMax`                       | Upper limit (in seconds) of the exponential backoff. If `null`, the upstream defaults are used. | `null` |
+| `settings.flower.urlPrefix`                           | If enabled, deploy Flower on a non-root URL | `""` |
+| `settings.flower.basicAuth`                           | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
+| `worker.podLabels`                                    | Additional labels to be set on the open-notification worker pods | `{}` |
+| `postgresql.primary.ersistence.enabled`               | Enable PostgreSQL persistency | `false` |
+| `postgresql.primary.persistence.size`                 | Configure PostgreSQL size | `"1Gi"` |
+| `postgresql.primary.persistence.existingClaim`        | Use an existing persistent volume claim | `null` |
+| `postgresql.global.postgresql.auth.database`          | The PostgreSQL database name | `"open-notificaties"` |
 | `postgresql.global.postgresql.auth.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
-| `flower.enabled`                                       | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
-| `flower.replicaCount`                                  | The number of replicas for Celery Flower | `1` | 
-| `flower.podLabels`                                     | Additional labels to be set for Celery Flower | `{}` | 
-| `flower.extraEnvVars`                                  | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
-| `flower.extraEnvVarsSecret`                            | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
-| `flower.ingress.enabled`                               | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
-| `flower.ingress.annotations`                           | Additional annotations on the Flower Ingress | `{}` |
-| `flower.ingress.hosts`                                 | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
-| `flower.ingress.tls`                                   | Flower Ingress TLS settings | `"[]"` |
-| `redis.usePassword`                                    | Use a Redis password | `false` |
-| `redis.cluster.enabled`                                | Enable Redis cluster | `false` |
-| `redis.persistence.existingClaim`                      | Use existing persistent volume claim for Redis | `""` |
-| `redis.master.persistence.enabled`                     | Enable persistency for Redis master | `false` |
-| `redis.master.persistence.size`                        | The size of the Redis master persistent volume | `"1Gi"` |
-| `rabbitmq.auth.username`                               | RabbitMQ username | `"guest"` |
-| `rabbitmq.auth.password`                               | RabbitMQ password | `"guest"` |
-| `rabbitmq.auth.erlangCookie`                           | RabbitMQ Erlang Cookie | `"SUPER-SECRET"` |
-| `rabbitmq.persistence.enabled`                         | Enable RabbitMQ persistency | `false` |
-| `rabbitmq.persistence.size`                            | Configure RabbitMQ size | `"1Gi"` |
-| `rabbitmq.persistence.existingClaim`                   | Use an existing persistent volume claim | `null` |
+| `flower.enabled`                                      | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
+| `flower.replicaCount`                                 | The number of replicas for Celery Flower | `1` | 
+| `flower.podLabels`                                    | Additional labels to be set for Celery Flower | `{}` | 
+| `flower.extraEnvVars`                                 | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
+| `flower.extraEnvVarsSecret`                           | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
+| `flower.ingress.enabled`                              | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
+| `flower.ingress.annotations`                          | Additional annotations on the Flower Ingress | `{}` |
+| `flower.ingress.hosts`                                | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
+| `flower.ingress.tls`                                  | Flower Ingress TLS settings | `"[]"` |
+| `redis.auth.enabled`                                  | Use a Redis password | `false` |
+| `redis.master.persistence.enabled`                    | Enable persistency for Redis master | `false` |
+| `redis.master.persistence.size`                       | The size of the Redis master persistent volume | `"1Gi"` |
+| `redis.master.persistence.existingClaim`              | Use existing persistent volume claim for Redis | `""` |
+| `rabbitmq.auth.username`                              | RabbitMQ username | `"guest"` |
+| `rabbitmq.auth.password`                              | RabbitMQ password | `"guest"` |
+| `rabbitmq.auth.erlangCookie`                          | RabbitMQ Erlang Cookie | `"SUPER-SECRET"` |
+| `rabbitmq.persistence.enabled`                        | Enable RabbitMQ persistency | `false` |
+| `rabbitmq.persistence.size`                           | Configure RabbitMQ size | `"1Gi"` |
+| `rabbitmq.persistence.existingClaim`                  | Use an existing persistent volume claim | `null` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -62,71 +62,71 @@ table below describes the supported versions
 
 ## Configuration
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `tags.postgresql` | Install PostgreSQL subchart | `true` |
-| `tags.redis` | Install Redis subchart | `true` |
-| `tags.rabbitmq` | Install RabbitMQ subchart | `true` |
-| `image.repository` | The repository of the Docker image | `openzaak/open-notificaties` |
-| `image.tag` | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
-| `replicaCount` | The number of replicas | `1` |
-| `podLabels` | Additional labels to be set on the open-notification API pods | `{}` |
-| `ingress.enabled` | Expose the application through an ingress | `false` |
-| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
-| `ingress.hosts` | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
-| `ingress.tls` | Ingress TLS settings | `"[]"` |
-| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
-| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
-| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
-| `settings.database.host` | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
-| `settings.database.port` | The port of PostgreSQL | `5432` |
-| `settings.database.username` | The username of PostgreSQL | `"postgres"` |
-| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
-| `settings.database.name` | The database name of PostgreSQL | `"open-notificaties"` |
-| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
-| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
-| `settings.cache.default` | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
-| `settings.cache.axes` | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
-| `settings.email.host` | The hostname of the SMTP server | `"localhost"` |
-| `settings.email.port` | The port of the SMTP server | `25` |
-| `settings.email.username` | The username of the SMTP server | `""` |
-| `settings.email.password` | The password of the SMTP server | `""` |
-| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
-| `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
-| `settings.messageBroker.host` | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
-| `settings.celery.resultBackend` | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
-| `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
-| `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
-| `settings.autoRetry.maxRetries` | Maximum number of notification delivery retries. If `null`, the upstream defaults are used. | `null` |
-| `settings.autoRetry.backoff` | Exponential backoff, boolean or number. If a number, applies as a scale factor. If `null`, the upstream defaults are used. | `null` |
-| `settings.autoRetry.backoffMax` | Upper limit (in seconds) of the exponential backoff. If `null`, the upstream defaults are used. | `null` |
-| `settings.flower.urlPrefix` | If enabled, deploy Flower on a non-root URL | `""` |
-| `settings.flower.basicAuth` | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
-| `worker.podLabels` | Additional labels to be set on the open-notification worker pods | `{}` |
-| `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
-| `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
-| `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
-| `postgresql.postgresqlDatabase` | The PostgreSQL database name | `"open-notificaties"` |
-| `postgresql.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
-| `flower.enabled` | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
-| `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
-| `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
-| `flower.extraEnvVars` | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
-| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
-| `flower.ingress.enabled` | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
-| `flower.ingress.annotations` | Additional annotations on the Flower Ingress | `{}` |
-| `flower.ingress.hosts` | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
-| `flower.ingress.tls` | Flower Ingress TLS settings | `"[]"` |
-| `redis.usePassword` | Use a Redis password | `false` |
-| `redis.cluster.enabled` | Enable Redis cluster | `false` |
-| `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |
-| `redis.master.persistence.enabled` | Enable persistency for Redis master | `false` |
-| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"` |
-| `rabbitmq.auth.username` | RabbitMQ username | `"guest"` |
-| `rabbitmq.auth.password` | RabbitMQ password | `"guest"` |
-| `rabbitmq.auth.erlangCookie` | RabbitMQ Erlang Cookie | `"SUPER-SECRET"` |
-| `rabbitmq.persistence.enabled` | Enable RabbitMQ persistency | `false` |
-| `rabbitmq.persistence.size` | Configure RabbitMQ size | `"1Gi"` |
-| `rabbitmq.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
+| Parameter                                              | Description | Default |
+|--------------------------------------------------------| ----------- | ------- |
+| `tags.postgresql`                                      | Install PostgreSQL subchart | `true` |
+| `tags.redis`                                           | Install Redis subchart | `true` |
+| `tags.rabbitmq`                                        | Install RabbitMQ subchart | `true` |
+| `image.repository`                                     | The repository of the Docker image | `openzaak/open-notificaties` |
+| `image.tag`                                            | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
+| `replicaCount`                                         | The number of replicas | `1` |
+| `podLabels`                                            | Additional labels to be set on the open-notification API pods | `{}` |
+| `ingress.enabled`                                      | Expose the application through an ingress | `false` |
+| `ingress.annotations`                                  | Additional annotations on the API ingress | `{}` |
+| `ingress.hosts`                                        | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
+| `ingress.tls`                                          | Ingress TLS settings | `"[]"` |
+| `existingSecret`                                       | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
+| `settings.allowedHosts`                                | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
+| `settings.secretKey`                                   | The secret key of the application | `"SOME-RANDOM-SECRET"` |
+| `settings.database.host`                               | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
+| `settings.database.port`                               | The port of PostgreSQL | `5432` |
+| `settings.database.username`                           | The username of PostgreSQL | `"postgres"` |
+| `settings.database.password`                           | The password of PostgreSQL | `"SUPER-SECRET"` |
+| `settings.database.name`                               | The database name of PostgreSQL | `"open-notificaties"` |
+| `settings.database.sslmode`                            | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
+| `settings.numProxies`                                  | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
+| `settings.cache.default`                               | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
+| `settings.cache.axes`                                  | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
+| `settings.email.host`                                  | The hostname of the SMTP server | `"localhost"` |
+| `settings.email.port`                                  | The port of the SMTP server | `25` |
+| `settings.email.username`                              | The username of the SMTP server | `""` |
+| `settings.email.password`                              | The password of the SMTP server | `""` |
+| `settings.email.useTLS`                                | Use TLS for connecting to SMTP server | `false` |
+| `settings.sentry.dsn`                                  | The DSN for Sentry Logging | `""` |
+| `settings.messageBroker.host`                          | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
+| `settings.celery.resultBackend`                        | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
+| `settings.isHttps`                                     | Used to construct absolute URLs and controls a variety of security settings | `true` |
+| `settings.debug`                                       | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `settings.autoRetry.maxRetries`                        | Maximum number of notification delivery retries. If `null`, the upstream defaults are used. | `null` |
+| `settings.autoRetry.backoff`                           | Exponential backoff, boolean or number. If a number, applies as a scale factor. If `null`, the upstream defaults are used. | `null` |
+| `settings.autoRetry.backoffMax`                        | Upper limit (in seconds) of the exponential backoff. If `null`, the upstream defaults are used. | `null` |
+| `settings.flower.urlPrefix`                            | If enabled, deploy Flower on a non-root URL | `""` |
+| `settings.flower.basicAuth`                            | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
+| `worker.podLabels`                                     | Additional labels to be set on the open-notification worker pods | `{}` |
+| `postgresql.persistence.enabled`                       | Enable PostgreSQL persistency | `false` |
+| `postgresql.persistence.size`                          | Configure PostgreSQL size | `"1Gi"` |
+| `postgresql.persistence.existingClaim`                 | Use an existing persistent volume claim | `null` |
+| `postgresql.global.postgresql.auth.database`           | The PostgreSQL database name | `"open-notificaties"` |
+| `postgresql.global.postgresql.auth.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
+| `flower.enabled`                                       | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
+| `flower.replicaCount`                                  | The number of replicas for Celery Flower | `1` | 
+| `flower.podLabels`                                     | Additional labels to be set for Celery Flower | `{}` | 
+| `flower.extraEnvVars`                                  | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
+| `flower.extraEnvVarsSecret`                            | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
+| `flower.ingress.enabled`                               | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
+| `flower.ingress.annotations`                           | Additional annotations on the Flower Ingress | `{}` |
+| `flower.ingress.hosts`                                 | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
+| `flower.ingress.tls`                                   | Flower Ingress TLS settings | `"[]"` |
+| `redis.usePassword`                                    | Use a Redis password | `false` |
+| `redis.cluster.enabled`                                | Enable Redis cluster | `false` |
+| `redis.persistence.existingClaim`                      | Use existing persistent volume claim for Redis | `""` |
+| `redis.master.persistence.enabled`                     | Enable persistency for Redis master | `false` |
+| `redis.master.persistence.size`                        | The size of the Redis master persistent volume | `"1Gi"` |
+| `rabbitmq.auth.username`                               | RabbitMQ username | `"guest"` |
+| `rabbitmq.auth.password`                               | RabbitMQ password | `"guest"` |
+| `rabbitmq.auth.erlangCookie`                           | RabbitMQ Erlang Cookie | `"SUPER-SECRET"` |
+| `rabbitmq.persistence.enabled`                         | Enable RabbitMQ persistency | `false` |
+| `rabbitmq.persistence.size`                            | Configure RabbitMQ size | `"1Gi"` |
+| `rabbitmq.persistence.existingClaim`                   | Use an existing persistent volume claim | `null` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -28,7 +28,7 @@ If you want to use your own instance of Redis, Postgres and RabbitMQ instead, yo
 
 ```bash
 
-helm install open-zaak open-zaak/open-zaak \
+helm install open-notificaties open-zaak/open-notificaties \
     --set "tags.redis=false" \
     --set "tags.postgresql=false" \
     --set "tags.rabbitmq=false" \

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -46,7 +46,7 @@ helm install open-notificaties open-zaak/open-notificaties \
     --set "ingress.hosts={open-notificaties.gemeente.nl}"
 ```
 
-You will probably need to set more values to configure the connection to your own Redis and Postgres instances.
+You will probably need to set more values to configure the connection to your own Redis, Postgres and RabbitMQ instances.
 
 ## Chart and Open Notificaties versions alignment
 

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -24,6 +24,24 @@ helm install open-notificaties open-zaak/open-notificaties \
     --set "ingress.hosts={open-notificaties.gemeente.nl}"
 ```
 
+If you want to use your own instance of Redis, Postgres and RabbitMQ instead, you can disable the subcharts:
+
+```bash
+
+helm install open-zaak open-zaak/open-zaak \
+    --set "tags.redis=false" \
+    --set "tags.postgresql=false" \
+    --set "tags.rabbitmq=false" \
+    --set "settings.database.host=postgres.gemeente.nl" \
+    --set "settings.cache.default=redis.gemeente.nl:6379/1" \
+    --set "settings.cache.axes=redis.gemeente.nl:6379/1" \
+    --set "settings.celery.resultBackend=redis.gemeente.nl:6379/2" \
+    --set "settings.messageBroker.host=rabbitmq.gemeente.nl" \
+    --set "settings.allowedHosts=open-notificaties.gemeente.nl" \
+    --set "ingress.enabled=true" \
+    --set "ingress.hosts={open-notificaties.gemeente.nl}"
+```
+
 :warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
 
 ## Chart and Open Notificaties versions alignment

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -24,7 +24,11 @@ helm install open-notificaties open-zaak/open-notificaties \
     --set "ingress.hosts={open-notificaties.gemeente.nl}"
 ```
 
-If you want to use your own instance of Redis, Postgres and RabbitMQ instead, you can disable the subcharts:
+:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+
+:warning: When you uninstall the chart, the PVCs will not be deleted. This can cause confusion during testing.
+
+If you want to use your own instances of Redis, Postgres and RabbitMQ instead, you can disable the subcharts:
 
 ```bash
 
@@ -42,7 +46,7 @@ helm install open-notificaties open-zaak/open-notificaties \
     --set "ingress.hosts={open-notificaties.gemeente.nl}"
 ```
 
-:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+You will probably need to set more values to configure the connection to your own Redis and Postgres instances.
 
 ## Chart and Open Notificaties versions alignment
 

--- a/charts/open-notificaties/README.md
+++ b/charts/open-notificaties/README.md
@@ -20,6 +20,7 @@ Install the Helm chart with:
 ```bash
 helm install open-notificaties open-zaak/open-notificaties \
     --set "settings.allowedHosts=open-notificaties.gemeente.nl" \
+    --set "settings.envVars.DJANGO_SUPERUSER_PASSWORD=appelmoes" \
     --set "ingress.enabled=true" \
     --set "ingress.hosts={open-notificaties.gemeente.nl}"
 ```
@@ -31,7 +32,6 @@ helm install open-notificaties open-zaak/open-notificaties \
 If you want to use your own instances of Redis, Postgres and RabbitMQ instead, you can disable the subcharts:
 
 ```bash
-
 helm install open-notificaties open-zaak/open-notificaties \
     --set "tags.redis=false" \
     --set "tags.postgresql=false" \
@@ -42,6 +42,7 @@ helm install open-notificaties open-zaak/open-notificaties \
     --set "settings.celery.resultBackend=redis.gemeente.nl:6379/2" \
     --set "settings.messageBroker.host=rabbitmq.gemeente.nl" \
     --set "settings.allowedHosts=open-notificaties.gemeente.nl" \
+    --set "settings.envVars.DJANGO_SUPERUSER_PASSWORD=appelmoes" \
     --set "ingress.enabled=true" \
     --set "ingress.hosts={open-notificaties.gemeente.nl}"
 ```
@@ -62,70 +63,71 @@ table below describes the supported versions
 
 ## Configuration
 
-| Parameter                                             | Description | Default |
-|-------------------------------------------------------| ----------- | ------- |
-| `tags.postgresql`                                     | Install PostgreSQL subchart | `true` |
-| `tags.redis`                                          | Install Redis subchart | `true` |
-| `tags.rabbitmq`                                       | Install RabbitMQ subchart | `true` |
-| `image.repository`                                    | The repository of the Docker image | `openzaak/open-notificaties` |
-| `image.tag`                                           | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
-| `replicaCount`                                        | The number of replicas | `1` |
-| `podLabels`                                           | Additional labels to be set on the open-notification API pods | `{}` |
-| `ingress.enabled`                                     | Expose the application through an ingress | `false` |
-| `ingress.annotations`                                 | Additional annotations on the API ingress | `{}` |
-| `ingress.hosts`                                       | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
-| `ingress.tls`                                         | Ingress TLS settings | `"[]"` |
-| `existingSecret`                                      | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
-| `settings.allowedHosts`                               | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
-| `settings.secretKey`                                  | The secret key of the application | `"SOME-RANDOM-SECRET"` |
-| `settings.database.host`                              | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
-| `settings.database.port`                              | The port of PostgreSQL | `5432` |
-| `settings.database.username`                          | The username of PostgreSQL | `"postgres"` |
-| `settings.database.password`                          | The password of PostgreSQL | `"SUPER-SECRET"` |
-| `settings.database.name`                              | The database name of PostgreSQL | `"open-notificaties"` |
-| `settings.database.sslmode`                           | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
-| `settings.numProxies`                                 | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
-| `settings.cache.default`                              | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
-| `settings.cache.axes`                                 | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
-| `settings.email.host`                                 | The hostname of the SMTP server | `"localhost"` |
-| `settings.email.port`                                 | The port of the SMTP server | `25` |
-| `settings.email.username`                             | The username of the SMTP server | `""` |
-| `settings.email.password`                             | The password of the SMTP server | `""` |
-| `settings.email.useTLS`                               | Use TLS for connecting to SMTP server | `false` |
-| `settings.sentry.dsn`                                 | The DSN for Sentry Logging | `""` |
-| `settings.messageBroker.host`                         | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
-| `settings.celery.resultBackend`                       | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
-| `settings.isHttps`                                    | Used to construct absolute URLs and controls a variety of security settings | `true` |
-| `settings.debug`                                      | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
-| `settings.autoRetry.maxRetries`                       | Maximum number of notification delivery retries. If `null`, the upstream defaults are used. | `null` |
-| `settings.autoRetry.backoff`                          | Exponential backoff, boolean or number. If a number, applies as a scale factor. If `null`, the upstream defaults are used. | `null` |
-| `settings.autoRetry.backoffMax`                       | Upper limit (in seconds) of the exponential backoff. If `null`, the upstream defaults are used. | `null` |
-| `settings.flower.urlPrefix`                           | If enabled, deploy Flower on a non-root URL | `""` |
-| `settings.flower.basicAuth`                           | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
-| `worker.podLabels`                                    | Additional labels to be set on the open-notification worker pods | `{}` |
-| `postgresql.primary.ersistence.enabled`               | Enable PostgreSQL persistency | `false` |
-| `postgresql.primary.persistence.size`                 | Configure PostgreSQL size | `"1Gi"` |
-| `postgresql.primary.persistence.existingClaim`        | Use an existing persistent volume claim | `null` |
-| `postgresql.global.postgresql.auth.database`          | The PostgreSQL database name | `"open-notificaties"` |
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `tags.postgresql` | Install PostgreSQL subchart | `true` |
+| `tags.redis` | Install Redis subchart | `true` |
+| `tags.rabbitmq` | Install RabbitMQ subchart | `true` |
+| `image.repository` | The repository of the Docker image | `openzaak/open-notificaties` |
+| `image.tag` | The tag of the Docker image | `""` (uses `.Chart.AppVersion` by default) |
+| `replicaCount` | The number of replicas | `1` |
+| `podLabels` | Additional labels to be set on the open-notification API pods | `{}` |
+| `ingress.enabled` | Expose the application through an ingress | `false` |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
+| `ingress.hosts` | Ingress hosts | `"{open-notificaties.gemeente.nl}"` |
+| `ingress.tls` | Ingress TLS settings | `"[]"` |
+| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret. This secret is also used for the Worker and Flower components. | `null` |
+| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-notificaties.gemeente.nl"` |
+| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
+| `settings.database.host` | The hostname of PostgreSQL | `"open-notificaties-postgresql"` |
+| `settings.database.port` | The port of PostgreSQL | `5432` |
+| `settings.database.username` | The username of PostgreSQL | `"postgres"` |
+| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
+| `settings.database.name` | The database name of PostgreSQL | `"open-notificaties"` |
+| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
+| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 1 if exposing the application through an ingress | `0`  |
+| `settings.cache.default` | The Redis cache for the default cache | `"open-notificaties-redis-master:6379/0"` |
+| `settings.cache.axes` | The Redis cache for the axes cache | `"open-notificaties-redis-master:6379/0"` |
+| `settings.email.host` | The hostname of the SMTP server | `"localhost"` |
+| `settings.email.port` | The port of the SMTP server | `25` |
+| `settings.email.username` | The username of the SMTP server | `""` |
+| `settings.email.password` | The password of the SMTP server | `""` |
+| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
+| `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
+| `settings.messageBroker.host` | The URL to the Celery broker | `"open-notificaties-rabbitmq"` |
+| `settings.celery.resultBackend` | The URL to the Celery result backend | `"redis://open-notificaties-redis-master:6379/1"` |
+| `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
+| `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `settings.autoRetry.maxRetries` | Maximum number of notification delivery retries. If `null`, the upstream defaults are used. | `null` |
+| `settings.autoRetry.backoff` | Exponential backoff, boolean or number. If a number, applies as a scale factor. If `null`, the upstream defaults are used. | `null` |
+| `settings.autoRetry.backoffMax` | Upper limit (in seconds) of the exponential backoff. If `null`, the upstream defaults are used. | `null` |
+| `settings.flower.urlPrefix` | If enabled, deploy Flower on a non-root URL | `""` |
+| `settings.flower.basicAuth` | Secure Flower with [Basic Authentication](https://flower.readthedocs.io/en/latest/config.html#basic-auth). This is a comma-separated list of `username:password`. You should configure this when `flower.ingress.enabled` is set to true. | `""` |
+| `settings.envVars.*` | Environment variables for the application. See [Example config](https://github.com/open-zaak/open-notificaties/blob/main/docker-compose.yml) for more info | see [values.yaml]                                 |
+| `worker.podLabels` | Additional labels to be set on the open-notification worker pods | `{}` |
+| `postgresql.primary.ersistence.enabled` | Enable PostgreSQL persistency | `false` |
+| `postgresql.primary.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
+| `postgresql.primary.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
+| `postgresql.global.postgresql.auth.database` | The PostgreSQL database name | `"open-notificaties"` |
 | `postgresql.global.postgresql.auth.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
-| `flower.enabled`                                      | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
-| `flower.replicaCount`                                 | The number of replicas for Celery Flower | `1` | 
-| `flower.podLabels`                                    | Additional labels to be set for Celery Flower | `{}` | 
-| `flower.extraEnvVars`                                 | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
-| `flower.extraEnvVarsSecret`                           | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
-| `flower.ingress.enabled`                              | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
-| `flower.ingress.annotations`                          | Additional annotations on the Flower Ingress | `{}` |
-| `flower.ingress.hosts`                                | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
-| `flower.ingress.tls`                                  | Flower Ingress TLS settings | `"[]"` |
-| `redis.auth.enabled`                                  | Use a Redis password | `false` |
-| `redis.master.persistence.enabled`                    | Enable persistency for Redis master | `false` |
-| `redis.master.persistence.size`                       | The size of the Redis master persistent volume | `"1Gi"` |
-| `redis.master.persistence.existingClaim`              | Use existing persistent volume claim for Redis | `""` |
-| `rabbitmq.auth.username`                              | RabbitMQ username | `"guest"` |
-| `rabbitmq.auth.password`                              | RabbitMQ password | `"guest"` |
-| `rabbitmq.auth.erlangCookie`                          | RabbitMQ Erlang Cookie | `"SUPER-SECRET"` |
-| `rabbitmq.persistence.enabled`                        | Enable RabbitMQ persistency | `false` |
-| `rabbitmq.persistence.size`                           | Configure RabbitMQ size | `"1Gi"` |
-| `rabbitmq.persistence.existingClaim`                  | Use an existing persistent volume claim | `null` |
+| `flower.enabled` | Whether or not to deploy the [Flower](https://flower.readthedocs.io/en/latest/) component, which is a monitoring tool for Celery  | `false` |
+| `flower.replicaCount` | The number of replicas for Celery Flower | `1` | 
+| `flower.podLabels` | Additional labels to be set for Celery Flower | `{}` | 
+| `flower.extraEnvVars` | Configure Flower through additional environment variables. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html)  | `{}` | 
+| `flower.extraEnvVarsSecret` | Configure Flower through additional environment variables. This property should contain secrets like basic-auth. For a full list of possibilities, see [Flower config docs](https://flower.readthedocs.io/en/latest/config.html) | `{}` |
+| `flower.ingress.enabled` | Use a dedicated Ingress for Flower, which can act as a Management Ingress. When `Values.ingress.enabled` is set to true and this parameter to false, then Flower will be exposed on the main Ingress. | `false` | 
+| `flower.ingress.annotations` | Additional annotations on the Flower Ingress | `{}` |
+| `flower.ingress.hosts` | Flower Ingress hosts | `"{open-notificaties-flower.gemeente.nl}"` |
+| `flower.ingress.tls` | Flower Ingress TLS settings | `"[]"` |
+| `redis.auth.enabled` | Use a Redis password | `false` |
+| `redis.master.persistence.enabled` | Enable persistency for Redis master | `false` |
+| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"` |
+| `redis.master.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |
+| `rabbitmq.auth.username` | RabbitMQ username | `"guest"` |
+| `rabbitmq.auth.password` | RabbitMQ password | `"guest"` |
+| `rabbitmq.auth.erlangCookie` | RabbitMQ Erlang Cookie | `"SUPER-SECRET"` |
+| `rabbitmq.persistence.enabled` | Enable RabbitMQ persistency | `false` |
+| `rabbitmq.persistence.size` | Configure RabbitMQ size | `"1Gi"` |
+| `rabbitmq.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/open-notificaties/templates/configmap.yaml
+++ b/charts/open-notificaties/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "open-notificaties.labels" . | nindent 4 }}
 data:
-  ALLOWED_HOSTS: "{{ include "open-notificaties.fullname" . }},{{ .Values.settings.allowedHosts | toString }}"
+  ALLOWED_HOSTS: "{{ include "open-notificaties.fullname" . }},{{ include "open-notificaties.fullname" . }}.{{ .Release.Namespace }},{{ include "open-notificaties.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local,{{ .Values.settings.allowedHosts | toString }}"
   CACHE_AXES: {{ .Values.settings.cache.axes | toString | quote }}
   CACHE_DEFAULT: {{ .Values.settings.cache.default | toString | quote }}
   DB_NAME: {{ .Values.settings.database.name | toString | quote }}
@@ -40,4 +40,7 @@ data:
   {{- range $index, $index_value := .Values.flower.extraEnvVars }}
   {{ $index }}: {{ $index_value | toString | quote }}
   {{- end }}
+  {{- end }}
+  {{- range $index, $value := .Values.settings.envVars }}
+  {{ $index }}: {{ $value | toString | quote }}
   {{- end }}

--- a/charts/open-notificaties/templates/deployment.yaml
+++ b/charts/open-notificaties/templates/deployment.yaml
@@ -47,6 +47,21 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          lifecycle:
+            postStart:
+              exec:
+                # exit 0 = Don't fail because then the container will keep restarting without logging what is wrong.
+                command:
+                  - bash
+                  - -c
+                  - |
+                    ( echo "=== postStart script started at $(date) ==="
+                      set -x
+                      HEXPORT=$( printf '%X' 8000 )
+                      until grep -q ":$HEXPORT" /proc/net/tcp; do sleep 5; done
+                      python /app/src/manage.py setup_configuration --no-selftest
+                      exit 0
+                    ) >> /app/log/postStart.log 2>&1
           livenessProbe:
             httpGet:
               path: /

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -196,8 +196,11 @@ postgresql:
     size: 1Gi
     existingClaim: null
 
-  postgresqlDatabase: open-notificaties
-  postgresqlPassword: SUPER-SECRET
+  global:
+    postgresql:
+      auth:
+        database: open-notificaties
+        postgresPassword: SUPER-SECRET
 
 ##################
 # Redis subchart #

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -191,10 +191,11 @@ settings:
 #######################
 
 postgresql:
-  persistence:
-    enabled: false
-    size: 1Gi
-    existingClaim: null
+  primary:
+    persistence:
+      enabled: false
+      size: 1Gi
+      existingClaim: null
 
   global:
     postgresql:
@@ -207,18 +208,14 @@ postgresql:
 ##################
 
 redis:
-  usePassword: false
-
-  cluster:
+  auth:
     enabled: false
-
-  persistence:
-    existingClaim: null
 
   master:
     persistence:
       enabled: false
       size: 1Gi
+      existingClaim: null
 
 #####################
 # RabbitMQ subchart #

--- a/charts/open-notificaties/values.yaml
+++ b/charts/open-notificaties/values.yaml
@@ -104,7 +104,7 @@ worker:
     # targetMemoryUtilizationPercentage: 80
 
 flower:
-  enabled: true
+  enabled: false
   replicaCount: 1
   podLabels: {}
   service:
@@ -185,6 +185,21 @@ settings:
   flower:
     urlPrefix: ""
     basicAuth: ""
+
+  envVars:
+    OPENNOTIFICATIES_SUPERUSER_USERNAME: admin
+    OPENNOTIFICATIES_SUPERUSER_EMAIL: admin@admin.org
+    # To provide an initial password set: settings.envVars.DJANGO_SUPERUSER_PASSWORD
+    OPENNOTIFICATIES_DOMAIN: open-notificaties.gemeente.nl
+    OPENNOTIFICATIES_ORGANIZATION: Gemeente
+    DEMO_CONFIG_ENABLE: false
+    # Notificaties -> OpenZaak auth config
+    AUTORISATIES_API_ROOT: http://open-zaak.default.svc.cluster.local/autorisaties/api/v1/
+    NOTIF_OPENZAAK_CLIENT_ID: open-notificaties
+    NOTIF_OPENZAAK_SECRET: NOTIF_OPENZAAK_SECRET
+    # OpenZaak -> Notificaties auth config
+    OPENZAAK_NOTIF_CLIENT_ID: open-zaak
+    OPENZAAK_NOTIF_SECRET: OPENZAAK_NOTIF_SECRET
 
 #######################
 # PostgreSQL subchart #

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 version: 0.8.1
 appVersion: "1.7.1"
 
-# dependencies:
-#   - name: postgresql
-#     version: ~10.12.0
-#     repository: https://charts.bitnami.com/bitnami
-#     tags:
-#       - postgresql
-#   - name: redis
-#     version: ~13.0.0
-#     repository: https://charts.bitnami.com/bitnami
-#     tags:
-#       - redis
+dependencies:
+  - name: postgresql
+    version: ~15.5.5
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - postgresql
+  - name: redis
+    version: ~19.5.2
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - redis

--- a/charts/open-zaak/Chart.yaml
+++ b/charts/open-zaak/Chart.yaml
@@ -3,8 +3,9 @@ name: open-zaak
 description: Productiewaardige API's voor Zaakgericht Werken
 
 type: application
-version: 0.8.1
-appVersion: "1.7.1"
+version: 0.8.2
+# https://github.com/open-zaak/open-zaak/tags
+appVersion: 1.12.4
 
 dependencies:
   - name: postgresql

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -23,6 +23,10 @@ helm install open-zaak open-zaak/open-zaak \
     --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
+:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+
+:warning: When you uninstall the chart, the PVCs will not be deleted. This can cause confusion during testing.
+
 If you want to use your own instance of Redis and Postgres instead, you can disable the subcharts:
 
 ```bash
@@ -38,7 +42,7 @@ helm install open-zaak open-zaak/open-zaak \
 --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
-:warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
+You will probably need to set more values to configure the connection to your own Redis and Postgres instances.
 
 ## Chart and Open Zaak versions alignment
 

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -23,6 +23,21 @@ helm install open-zaak open-zaak/open-zaak \
     --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
+If you want to use your own instance of Redis and Postgres instead, you can disable the subcharts:
+
+```bash
+
+helm install open-zaak open-zaak/open-zaak \
+--set "tags.redis=false" \
+--set "tags.postgresql=false" \
+--set "settings.database.host=postgres.gemeente.nl" \
+--set "settings.cache.default=redis.gemeente.nl:6379/0" \
+--set "settings.cache.axes=redis.gemeente.nl:6379/0" \
+--set "settings.allowedHosts=open-zaak.gemeente.nl" \
+--set "ingress.enabled=true" \
+--set "ingress.hosts={open-zaak.gemeente.nl}"
+```
+
 :warning: The default settings are unsafe for production usage. Configure proper secrets, enable persistency and consider High Availability (HA) for the database and the application.
 
 ## Chart and Open Zaak versions alignment

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -30,16 +30,15 @@ helm install open-zaak open-zaak/open-zaak \
 If you want to use your own instance of Redis and Postgres instead, you can disable the subcharts:
 
 ```bash
-
 helm install open-zaak open-zaak/open-zaak \
---set "tags.redis=false" \
---set "tags.postgresql=false" \
---set "settings.database.host=postgres.gemeente.nl" \
---set "settings.cache.default=redis.gemeente.nl:6379/0" \
---set "settings.cache.axes=redis.gemeente.nl:6379/0" \
---set "settings.allowedHosts=open-zaak.gemeente.nl" \
---set "ingress.enabled=true" \
---set "ingress.hosts={open-zaak.gemeente.nl}"
+    --set "tags.redis=false" \
+    --set "tags.postgresql=false" \
+    --set "settings.database.host=postgres.gemeente.nl" \
+    --set "settings.cache.default=redis.gemeente.nl:6379/0" \
+    --set "settings.cache.axes=redis.gemeente.nl:6379/0" \
+    --set "settings.allowedHosts=open-zaak.gemeente.nl" \
+    --set "ingress.enabled=true" \
+    --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
 
 You will probably need to set more values to configure the connection to your own Redis and Postgres instances.

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -19,6 +19,7 @@ Install the Helm chart with:
 ```bash
 helm install open-zaak open-zaak/open-zaak \
     --set "settings.allowedHosts=open-zaak.gemeente.nl" \
+    --set "settings.envVars.DJANGO_SUPERUSER_PASSWORD=appelmoes" \
     --set "ingress.enabled=true" \
     --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
@@ -37,6 +38,7 @@ helm install open-zaak open-zaak/open-zaak \
     --set "settings.cache.default=redis.gemeente.nl:6379/0" \
     --set "settings.cache.axes=redis.gemeente.nl:6379/0" \
     --set "settings.allowedHosts=open-zaak.gemeente.nl" \
+    --set "settings.envVars.DJANGO_SUPERUSER_PASSWORD=appelmoes" \
     --set "ingress.enabled=true" \
     --set "ingress.hosts={open-zaak.gemeente.nl}"
 ```
@@ -56,56 +58,57 @@ table below describes the supported versions
 
 ## Configuration
 
-| Parameter                                              | Description | Default                                  |
-|--------------------------------------------------------| ----------- |------------------------------------------|
-| `tags.postgresql`                                      | Install PostgreSQL subchart | `true`                                   |
-| `tags.redis`                                           | Install Redis subchart | `true`                                   |
-| `image.repository`                                     | The repository of the Docker image | `openzaak/open-zaak`                     |
-| `image.tag`                                            | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
-| `replicaCount`                                         | The number of replicas | `1`                                      |
-| `podLabels`                                            | Additional labels to be set on the open-zaak pods | `{}`                                     |
-| `ingress.enabled`                                      | Expose the application through an ingress | `false`                                  |
-| `ingress.annotations`                                  | Additional annotations on the API ingress | `{}`                                     |
-| `ingress.hosts`                                        | Ingress hosts | `"{open-zaak.gemeente.nl}"`              |
-| `ingress.tls`                                          | Ingress TLS settings | `"[]"`                                   |
-| `persistence.enabled`                                  | Enable persistency for application media | `false`                                  |
-| `persistence.storageClassName`                         | Storage class name for the PVC creation, must support RWX | `""`                                     |
-| `persistence.size`                                     | The size of the application media persistent volume | `"1Gi"`                                  |
-| `persistence.existingClaim`                            | Use an existing claim for application media | `null`                                   |
-| `existingSecret`                                       | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null`                                   |
-| `initContainers.volumePerms`                           | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true`                                   |
-| `settings.allowedHosts`                                | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"`                |
-| `settings.useXForwardedHost`                           | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false`                                  |
-| `settings.secretKey`                                   | The secret key of the application | `"SOME-RANDOM-SECRET"`                   |
-| `settings.database.host`                               | The hostname of PostgreSQL | `"open-zaak-postgresql"`                 |
-| `settings.database.port`                               | The port of PostgreSQL | `5432`                                   |
-| `settings.database.username`                           | The username of PostgreSQL | `"postgres"`                             |
-| `settings.database.password`                           | The password of PostgreSQL | `"SUPER-SECRET"`                         |
-| `settings.database.name`                               | The database name of PostgreSQL | `"open-zaak"`                            |
-| `settings.database.sslmode`                            | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"`                               |
-| `settings.numProxies`                                  | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`                                      |
-| `settings.cache.default`                               | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"`        |
-| `settings.cache.axes`                                  | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"`        |
-| `settings.email.host`                                  | The hostname of the SMTP server | `"localhost"`                            |
-| `settings.email.port`                                  | The port of the SMTP server | `25`                                     |
-| `settings.email.username`                              | The username of the SMTP server | `""`                                     |
-| `settings.email.password`                              | The password of the SMTP server | `""`                                     |
-| `settings.email.useTLS`                                | Use TLS for connecting to SMTP server | `false`                                  |
-| `settings.jwtExpiry`                                   | The expiry time for JWT tokens | `3600`                                   |
-| `settings.cmis.enabled`                                | Enable CMIS | `false`                                  |
-| `settings.cmis.mapperFile`                             | The CMIS mapper file | `""`                                     |
-| `settings.sentry.dsn`                                  | The DSN for Sentry Logging | `""`                                     |
-| `settings.isHttps`                                     | Used to construct absolute URLs and controls a variety of security settings | `true`                                   |
-| `settings.debug`                                       | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false`                                  |
-| `nginx.podLabels`                                      | Additional labels to be set on the nginx pods | `{}`                                     |
-| `postgresql.primary.persistence.enabled`               | Enable PostgreSQL persistency | `false`                                  |
-| `postgresql.primary.persistence.size`                  | Configure PostgreSQL size | `"1Gi"`                                  |
-| `postgresql.primary.persistence.existingClaim`         | Use an existing persistent volume claim | `null`                                   |
-| `postgresql.global.postgresql.auth.database`           | The PostgreSQL database name | `"open-zaak"`                            |
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `tags.postgresql` | Install PostgreSQL subchart | `true` |
+| `tags.redis` | Install Redis subchart | `true` |
+| `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
+| `image.tag` | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
+| `replicaCount` | The number of replicas | `1` |
+| `podLabels` | Additional labels to be set on the open-zaak pods | `{}` |
+| `ingress.enabled` | Expose the application through an ingress | `false` |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
+| `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"` |
+| `ingress.tls` | Ingress TLS settings | `"[]"` |
+| `persistence.enabled` | Enable persistency for application media | `false` |
+| `persistence.storageClassName` | Storage class name for the PVC creation, must support RWX | `""` |
+| `persistence.size` | The size of the application media persistent volume | `"1Gi"` |
+| `persistence.existingClaim` | Use an existing claim for application media | `null` |
+| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
+| `initContainers.volumePerms` | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true` |
+| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"` |
+| `settings.useXForwardedHost` | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false` |
+| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
+| `settings.database.host` | The hostname of PostgreSQL | `"open-zaak-postgresql"` |
+| `settings.database.port` | The port of PostgreSQL | `5432` |
+| `settings.database.username` | The username of PostgreSQL | `"postgres"` |
+| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
+| `settings.database.name` | The database name of PostgreSQL | `"open-zaak"` |
+| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
+| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`  |
+| `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"` |
+| `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"` |
+| `settings.email.host` | The hostname of the SMTP server | `"localhost"` |
+| `settings.email.port` | The port of the SMTP server | `25` |
+| `settings.email.username` | The username of the SMTP server | `""` |
+| `settings.email.password` | The password of the SMTP server | `""` |
+| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
+| `settings.jwtExpiry` | The expiry time for JWT tokens | `3600` |
+| `settings.cmis.enabled` | Enable CMIS | `false` |
+| `settings.cmis.mapperFile` | The CMIS mapper file | `""` |
+| `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
+| `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
+| `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
+| `settings.envVars.*` | Environment variables for the application. See [docs](https://open-zaak.readthedocs.io/en/latest/installation/config/env_config.html) for more info | see [values.yaml]                        |
+| `nginx.podLabels` | Additional labels to be set on the nginx pods | `{}` |
+| `postgresql.primary.persistence.enabled` | Enable PostgreSQL persistency | `false`                                  |
+| `postgresql.primary.persistence.size` | Configure PostgreSQL size | `"1Gi"`                                  |
+| `postgresql.primary.persistence.existingClaim` | Use an existing persistent volume claim | `null`                                   |
+| `postgresql.global.postgresql.auth.database` | The PostgreSQL database name | `"open-zaak"`                            |
 | `postgresql.global.postgresql.auth.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"`                         |
-| `redis.auth.enabled`                                   | Use a Redis password | `false`                                  |
-| `redis.master.persistence.enabled`                     | Enable persistency for Redis master | `false`                                  |
-| `redis.master.persistence.size`                        | The size of the Redis master persistent volume | `"1Gi"`                                  |
-| `redis.master.persistence.existingClaim`               | Use existing persistent volume claim for Redis | `""`                                     |
+| `redis.auth.enabled` | Use a Redis password | `false`                                  |
+| `redis.master.persistence.enabled`  | Enable persistency for Redis master | `false`                                  |
+| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"`                                  |
+| `redis.master.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""`                                     |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -56,57 +56,57 @@ table below describes the supported versions
 
 ## Configuration
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `tags.postgresql` | Install PostgreSQL subchart | `true` |
-| `tags.redis` | Install Redis subchart | `true` |
-| `image.repository` | The repository of the Docker image | `openzaak/open-zaak` |
+| Parameter | Description | Default                                  |
+| --------- | ----------- |------------------------------------------|
+| `tags.postgresql` | Install PostgreSQL subchart | `true`                                   |
+| `tags.redis` | Install Redis subchart | `true`                                   |
+| `image.repository` | The repository of the Docker image | `openzaak/open-zaak`                     |
 | `image.tag` | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
-| `replicaCount` | The number of replicas | `1` |
-| `podLabels` | Additional labels to be set on the open-zaak pods | `{}` |
-| `ingress.enabled` | Expose the application through an ingress | `false` |
-| `ingress.annotations` | Additional annotations on the API ingress | `{}` |
-| `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"` |
-| `ingress.tls` | Ingress TLS settings | `"[]"` |
-| `persistence.enabled` | Enable persistency for application media | `false` |
-| `persistence.storageClassName` | Storage class name for the PVC creation, must support RWX | `""` |
-| `persistence.size` | The size of the application media persistent volume | `"1Gi"` |
-| `persistence.existingClaim` | Use an existing claim for application media | `null` |
-| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null` |
-| `initContainers.volumePerms` | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true` |
-| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"` |
-| `settings.useXForwardedHost` | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false` |
-| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"` |
-| `settings.database.host` | The hostname of PostgreSQL | `"open-zaak-postgresql"` |
-| `settings.database.port` | The port of PostgreSQL | `5432` |
-| `settings.database.username` | The username of PostgreSQL | `"postgres"` |
-| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"` |
-| `settings.database.name` | The database name of PostgreSQL | `"open-zaak"` |
-| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"` |
-| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`  |
-| `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"` |
-| `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"` |
-| `settings.email.host` | The hostname of the SMTP server | `"localhost"` |
-| `settings.email.port` | The port of the SMTP server | `25` |
-| `settings.email.username` | The username of the SMTP server | `""` |
-| `settings.email.password` | The password of the SMTP server | `""` |
-| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false` |
-| `settings.jwtExpiry` | The expiry time for JWT tokens | `3600` |
-| `settings.cmis.enabled` | Enable CMIS | `false` |
-| `settings.cmis.mapperFile` | The CMIS mapper file | `""` |
-| `settings.sentry.dsn` | The DSN for Sentry Logging | `""` |
-| `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true` |
-| `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false` |
-| `nginx.podLabels` | Additional labels to be set on the nginx pods | `{}` |
-| `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false` |
-| `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"` |
-| `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null` |
-| `postgresql.postgresqlDatabase` | The PostgreSQL database name | `"open-zaak"` |
-| `postgresql.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"` |
-| `redis.usePassword` | Use a Redis password | `false` |
-| `redis.cluster.enabled` | Enable Redis cluster | `false` |
-| `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""` |
-| `redis.master.persistence.enabled` | Enable persistency for Redis master | `false` |
-| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"` |
+| `replicaCount` | The number of replicas | `1`                                      |
+| `podLabels` | Additional labels to be set on the open-zaak pods | `{}`                                     |
+| `ingress.enabled` | Expose the application through an ingress | `false`                                  |
+| `ingress.annotations` | Additional annotations on the API ingress | `{}`                                     |
+| `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"`              |
+| `ingress.tls` | Ingress TLS settings | `"[]"`                                   |
+| `persistence.enabled` | Enable persistency for application media | `false`                                  |
+| `persistence.storageClassName` | Storage class name for the PVC creation, must support RWX | `""`                                     |
+| `persistence.size` | The size of the application media persistent volume | `"1Gi"`                                  |
+| `persistence.existingClaim` | Use an existing claim for application media | `null`                                   |
+| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null`                                   |
+| `initContainers.volumePerms` | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true`                                   |
+| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"`                |
+| `settings.useXForwardedHost` | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false`                                  |
+| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"`                   |
+| `settings.database.host` | The hostname of PostgreSQL | `"open-zaak-postgresql"`                 |
+| `settings.database.port` | The port of PostgreSQL | `5432`                                   |
+| `settings.database.username` | The username of PostgreSQL | `"postgres"`                             |
+| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"`                         |
+| `settings.database.name` | The database name of PostgreSQL | `"open-zaak"`                            |
+| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"`                               |
+| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`                                      |
+| `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"`        |
+| `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"`        |
+| `settings.email.host` | The hostname of the SMTP server | `"localhost"`                            |
+| `settings.email.port` | The port of the SMTP server | `25`                                     |
+| `settings.email.username` | The username of the SMTP server | `""`                                     |
+| `settings.email.password` | The password of the SMTP server | `""`                                     |
+| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false`                                  |
+| `settings.jwtExpiry` | The expiry time for JWT tokens | `3600`                                   |
+| `settings.cmis.enabled` | Enable CMIS | `false`                                  |
+| `settings.cmis.mapperFile` | The CMIS mapper file | `""`                                     |
+| `settings.sentry.dsn` | The DSN for Sentry Logging | `""`                                     |
+| `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true`                                   |
+| `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false`                                  |
+| `nginx.podLabels` | Additional labels to be set on the nginx pods | `{}`                                     |
+| `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false`                                  |
+| `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"`                                  |
+| `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null`                                   |
+| `postgresql.global.postgresql.auth.database`           | The PostgreSQL database name | `"open-zaak"`                            |
+| `postgresql.global.postgresql.auth.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"`                         |
+| `redis.usePassword` | Use a Redis password | `false`                                  |
+| `redis.cluster.enabled` | Enable Redis cluster | `false`                                  |
+| `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""`                                     |
+| `redis.master.persistence.enabled` | Enable persistency for Redis master | `false`                                  |
+| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"`                                  |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/open-zaak/README.md
+++ b/charts/open-zaak/README.md
@@ -56,57 +56,56 @@ table below describes the supported versions
 
 ## Configuration
 
-| Parameter | Description | Default                                  |
-| --------- | ----------- |------------------------------------------|
-| `tags.postgresql` | Install PostgreSQL subchart | `true`                                   |
-| `tags.redis` | Install Redis subchart | `true`                                   |
-| `image.repository` | The repository of the Docker image | `openzaak/open-zaak`                     |
-| `image.tag` | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
-| `replicaCount` | The number of replicas | `1`                                      |
-| `podLabels` | Additional labels to be set on the open-zaak pods | `{}`                                     |
-| `ingress.enabled` | Expose the application through an ingress | `false`                                  |
-| `ingress.annotations` | Additional annotations on the API ingress | `{}`                                     |
-| `ingress.hosts` | Ingress hosts | `"{open-zaak.gemeente.nl}"`              |
-| `ingress.tls` | Ingress TLS settings | `"[]"`                                   |
-| `persistence.enabled` | Enable persistency for application media | `false`                                  |
-| `persistence.storageClassName` | Storage class name for the PVC creation, must support RWX | `""`                                     |
-| `persistence.size` | The size of the application media persistent volume | `"1Gi"`                                  |
-| `persistence.existingClaim` | Use an existing claim for application media | `null`                                   |
-| `existingSecret` | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null`                                   |
-| `initContainers.volumePerms` | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true`                                   |
-| `settings.allowedHosts` | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"`                |
-| `settings.useXForwardedHost` | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false`                                  |
-| `settings.secretKey` | The secret key of the application | `"SOME-RANDOM-SECRET"`                   |
-| `settings.database.host` | The hostname of PostgreSQL | `"open-zaak-postgresql"`                 |
-| `settings.database.port` | The port of PostgreSQL | `5432`                                   |
-| `settings.database.username` | The username of PostgreSQL | `"postgres"`                             |
-| `settings.database.password` | The password of PostgreSQL | `"SUPER-SECRET"`                         |
-| `settings.database.name` | The database name of PostgreSQL | `"open-zaak"`                            |
-| `settings.database.sslmode` | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"`                               |
-| `settings.numProxies` | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`                                      |
-| `settings.cache.default` | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"`        |
-| `settings.cache.axes` | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"`        |
-| `settings.email.host` | The hostname of the SMTP server | `"localhost"`                            |
-| `settings.email.port` | The port of the SMTP server | `25`                                     |
-| `settings.email.username` | The username of the SMTP server | `""`                                     |
-| `settings.email.password` | The password of the SMTP server | `""`                                     |
-| `settings.email.useTLS` | Use TLS for connecting to SMTP server | `false`                                  |
-| `settings.jwtExpiry` | The expiry time for JWT tokens | `3600`                                   |
-| `settings.cmis.enabled` | Enable CMIS | `false`                                  |
-| `settings.cmis.mapperFile` | The CMIS mapper file | `""`                                     |
-| `settings.sentry.dsn` | The DSN for Sentry Logging | `""`                                     |
-| `settings.isHttps` | Used to construct absolute URLs and controls a variety of security settings | `true`                                   |
-| `settings.debug` | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false`                                  |
-| `nginx.podLabels` | Additional labels to be set on the nginx pods | `{}`                                     |
-| `postgresql.persistence.enabled` | Enable PostgreSQL persistency | `false`                                  |
-| `postgresql.persistence.size` | Configure PostgreSQL size | `"1Gi"`                                  |
-| `postgresql.persistence.existingClaim` | Use an existing persistent volume claim | `null`                                   |
+| Parameter                                              | Description | Default                                  |
+|--------------------------------------------------------| ----------- |------------------------------------------|
+| `tags.postgresql`                                      | Install PostgreSQL subchart | `true`                                   |
+| `tags.redis`                                           | Install Redis subchart | `true`                                   |
+| `image.repository`                                     | The repository of the Docker image | `openzaak/open-zaak`                     |
+| `image.tag`                                            | The tag of the Docker image | `""` uses `.Chart.AppVersion` by default |
+| `replicaCount`                                         | The number of replicas | `1`                                      |
+| `podLabels`                                            | Additional labels to be set on the open-zaak pods | `{}`                                     |
+| `ingress.enabled`                                      | Expose the application through an ingress | `false`                                  |
+| `ingress.annotations`                                  | Additional annotations on the API ingress | `{}`                                     |
+| `ingress.hosts`                                        | Ingress hosts | `"{open-zaak.gemeente.nl}"`              |
+| `ingress.tls`                                          | Ingress TLS settings | `"[]"`                                   |
+| `persistence.enabled`                                  | Enable persistency for application media | `false`                                  |
+| `persistence.storageClassName`                         | Storage class name for the PVC creation, must support RWX | `""`                                     |
+| `persistence.size`                                     | The size of the application media persistent volume | `"1Gi"`                                  |
+| `persistence.existingClaim`                            | Use an existing claim for application media | `null`                                   |
+| `existingSecret`                                       | Refer to an existing secret to avoid managing secrets through Helm. See templates/secret.yaml for required contents of your existing secret | `null`                                   |
+| `initContainers.volumePerms`                           | Run the file-permission fix init container (for upgrades from Open Zaak < 1.5) | `true`                                   |
+| `settings.allowedHosts`                                | A comma-separated list of hosts allowed by the application | `"open-zaak.gemeente.nl"`                |
+| `settings.useXForwardedHost`                           | Whether to rely on the `X-Forwarded-Host` header from ingress for host detection | `false`                                  |
+| `settings.secretKey`                                   | The secret key of the application | `"SOME-RANDOM-SECRET"`                   |
+| `settings.database.host`                               | The hostname of PostgreSQL | `"open-zaak-postgresql"`                 |
+| `settings.database.port`                               | The port of PostgreSQL | `5432`                                   |
+| `settings.database.username`                           | The username of PostgreSQL | `"postgres"`                             |
+| `settings.database.password`                           | The password of PostgreSQL | `"SUPER-SECRET"`                         |
+| `settings.database.name`                               | The database name of PostgreSQL | `"open-zaak"`                            |
+| `settings.database.sslmode`                            | The SSL-mode used by the postgres client. See [docs](https://www.postgresql.org/docs/current/libpq-ssl.html) for more info | `"prefer"`                               |
+| `settings.numProxies`                                  | The number of reverse proxies between client and backend container. Set this to 2 if exposing the application through an ingress. This chart deploys one nginx reverse proxy already. | `1`                                      |
+| `settings.cache.default`                               | The Redis cache for the default cache | `"open-zaak-redis-master:6379/0"`        |
+| `settings.cache.axes`                                  | The Redis cache for the axes cache | `"open-zaak-redis-master:6379/0"`        |
+| `settings.email.host`                                  | The hostname of the SMTP server | `"localhost"`                            |
+| `settings.email.port`                                  | The port of the SMTP server | `25`                                     |
+| `settings.email.username`                              | The username of the SMTP server | `""`                                     |
+| `settings.email.password`                              | The password of the SMTP server | `""`                                     |
+| `settings.email.useTLS`                                | Use TLS for connecting to SMTP server | `false`                                  |
+| `settings.jwtExpiry`                                   | The expiry time for JWT tokens | `3600`                                   |
+| `settings.cmis.enabled`                                | Enable CMIS | `false`                                  |
+| `settings.cmis.mapperFile`                             | The CMIS mapper file | `""`                                     |
+| `settings.sentry.dsn`                                  | The DSN for Sentry Logging | `""`                                     |
+| `settings.isHttps`                                     | Used to construct absolute URLs and controls a variety of security settings | `true`                                   |
+| `settings.debug`                                       | Only set this to True on a local development environment. Various other security settings are derived from this setting | `false`                                  |
+| `nginx.podLabels`                                      | Additional labels to be set on the nginx pods | `{}`                                     |
+| `postgresql.primary.persistence.enabled`               | Enable PostgreSQL persistency | `false`                                  |
+| `postgresql.primary.persistence.size`                  | Configure PostgreSQL size | `"1Gi"`                                  |
+| `postgresql.primary.persistence.existingClaim`         | Use an existing persistent volume claim | `null`                                   |
 | `postgresql.global.postgresql.auth.database`           | The PostgreSQL database name | `"open-zaak"`                            |
 | `postgresql.global.postgresql.auth.postgresqlPassword` | The PostgreSQL administrative password | `"SUPER-SECRET"`                         |
-| `redis.usePassword` | Use a Redis password | `false`                                  |
-| `redis.cluster.enabled` | Enable Redis cluster | `false`                                  |
-| `redis.persistence.existingClaim` | Use existing persistent volume claim for Redis | `""`                                     |
-| `redis.master.persistence.enabled` | Enable persistency for Redis master | `false`                                  |
-| `redis.master.persistence.size` | The size of the Redis master persistent volume | `"1Gi"`                                  |
+| `redis.auth.enabled`                                   | Use a Redis password | `false`                                  |
+| `redis.master.persistence.enabled`                     | Enable persistency for Redis master | `false`                                  |
+| `redis.master.persistence.size`                        | The size of the Redis master persistent volume | `"1Gi"`                                  |
+| `redis.master.persistence.existingClaim`               | Use existing persistent volume claim for Redis | `""`                                     |
 
 Check [values.yaml](./values.yaml) for all the possible configuration options.

--- a/charts/open-zaak/templates/configmap.yaml
+++ b/charts/open-zaak/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "open-zaak.labels" . | nindent 4 }}
 data:
-  ALLOWED_HOSTS: "{{ include "open-zaak.fullname" . }},{{ include "open-zaak.fullname" . }}.{{ .Release.Namespace }},{{ .Values.settings.allowedHosts | toString }}"
+  ALLOWED_HOSTS: "{{ include "open-zaak.fullname" . }},{{ include "open-zaak.fullname" . }}.{{ .Release.Namespace }},{{ include "open-zaak.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local,{{ .Values.settings.allowedHosts | toString }}"
   {{- if .Values.settings.useXForwardedHost }}
   USE_X_FORWARDED_HOST: "True"
   {{- end }}
@@ -33,3 +33,6 @@ data:
   {{- end }}
   IS_HTTPS: {{ if .Values.settings.isHttps }}"True"{{ else }}"False"{{ end }}
   JWT_EXPIRY: {{ .Values.settings.jwtExpiry | toString | quote }}
+  {{- range $index, $value := .Values.settings.envVars }}
+  {{ $index }}: {{ $value | toString | quote }}
+  {{- end }}

--- a/charts/open-zaak/templates/deployment.yaml
+++ b/charts/open-zaak/templates/deployment.yaml
@@ -62,6 +62,21 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          lifecycle:
+            postStart:
+              exec:
+                # exit 0 = Don't fail because then the container will keep restarting without logging what is wrong.
+                command:
+                  - bash
+                  - -c
+                  - |
+                    ( echo "=== postStart script started at $(date) ==="
+                      set -x
+                      HEXPORT=$( printf '%X' 8000 )
+                      until grep -q ":$HEXPORT" /proc/net/tcp; do sleep 5; done
+                      python /app/src/manage.py setup_configuration --no-selftest
+                      exit 0
+                    ) >> /app/log/postStart.log 2>&1
           livenessProbe:
             httpGet:
               path: /

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -186,9 +186,11 @@ postgresql:
     size: 1Gi
     existingClaim: null
 
-  auth:
-    database: open-zaak
-    postgresPassword: SUPER-SECRET
+  global:
+    postgresql:
+      auth:
+        database: open-zaak
+        postgresPassword: SUPER-SECRET
 
 ##################
 # Redis subchart #

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -140,7 +140,20 @@ settings:
 
   debug: false
 
-  extraEnvVars: {}
+  envVars:
+    OPENZAAK_SUPERUSER_EMAIL: admin@admin.org
+    OPENZAAK_SUPERUSER_USERNAME: admin
+    # To provide an initial password set: settings.envVars.DJANGO_SUPERUSER_PASSWORD
+    OPENZAAK_DOMAIN: open-zaak.gemeente.nl
+    OPENZAAK_ORGANIZATION: Gemeente
+    DEMO_CONFIG_ENABLE: false
+    # Notificaties -> OpenZaak auth config
+    NOTIF_OPENZAAK_CLIENT_ID: open-notificaties
+    NOTIF_OPENZAAK_SECRET: NOTIF_OPENZAAK_SECRET
+    # OpenZaak -> Notificaties auth config
+    NOTIF_API_ROOT: http://open-notificaties.default.svc.cluster.local/api/v1/
+    OPENZAAK_NOTIF_CLIENT_ID: open-zaak
+    OPENZAAK_NOTIF_SECRET: OPENZAAK_NOTIF_SECRET
 
 nginx:
   image:

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -125,7 +125,7 @@ settings:
 
   cache:
     default: open-zaak-redis-master:6379/0
-    axes: open-zaak-redis-master:6379/0
+    axes: open-zaak-redis-master:6379/1
 
   sentry:
     dsn: ""
@@ -139,6 +139,8 @@ settings:
   isHttps: true
 
   debug: false
+
+  extraEnvVars: {}
 
 nginx:
   image:
@@ -181,10 +183,11 @@ nginx:
 #######################
 
 postgresql:
-  persistence:
-    enabled: false
-    size: 1Gi
-    existingClaim: null
+  primary:
+    persistence:
+      enabled: false
+      size: 1Gi
+      existingClaim: null
 
   global:
     postgresql:
@@ -197,15 +200,11 @@ postgresql:
 ##################
 
 redis:
-  usePassword: false
-
-  cluster:
+  auth:
     enabled: false
-
-  persistence:
-    existingClaim: null
 
   master:
     persistence:
       enabled: false
       size: 1Gi
+      existingClaim: null

--- a/charts/open-zaak/values.yaml
+++ b/charts/open-zaak/values.yaml
@@ -59,7 +59,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  className: ""    
+  className: ""
   hosts:
     - open-zaak.gemeente.nl
   tls: []
@@ -186,8 +186,9 @@ postgresql:
     size: 1Gi
     existingClaim: null
 
-  postgresqlDatabase: open-zaak
-  postgresqlPassword: SUPER-SECRET
+  auth:
+    database: open-zaak
+    postgresPassword: SUPER-SECRET
 
 ##################
 # Redis subchart #


### PR DESCRIPTION
- Updated Open-Zaak to 1.12.4
- Updated Open-Notificaties to 1.6.0
- Added postStart scripts to execute `setup_configuration`
- Added envVars to Helm which are passed to the application
- Disabled Flower by default in Open-Notificaties, caused duplicate ingress rule
- Several fixes to deploy working applications
- Updated READMEs

This PR includes the changes from #39 and #35
Fixes #40
